### PR TITLE
Custodian + Fontaine [MAP] Removal

### DIFF
--- a/maps/__Liberty/map/_Liberty_Colony.dmm
+++ b/maps/__Liberty/map/_Liberty_Colony.dmm
@@ -245,12 +245,10 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/liberty/security/armoryshop)
 "adx" = (
-/obj/structure/sign/faction/custodians{
-	pixel_x = 32
-	},
-/obj/structure/flora/ausbushes/grassybush,
-/turf/simulated/floor/asteroid/grass,
-/area/liberty/bonfire/stronghold)
+/obj/effect/window_lwall_spawn/smartspawn,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/liberty/bonfire/bioreactor)
 "adG" = (
 /obj/structure/grille,
 /obj/structure/grille,
@@ -507,7 +505,6 @@
 /turf/simulated/floor/industrial/grey_slates,
 /area/liberty/maintenance/undergroundfloor2east)
 "agT" = (
-/obj/machinery/power/torchbearer,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -522,25 +519,13 @@
 /obj/machinery/holoposter{
 	pixel_y = -33
 	},
-/turf/simulated/floor/tiled/dark/techfloor_grid,
+/turf/simulated/floor/wood/wild1,
 /area/liberty/hallway/surface/section1)
 "ahe" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
-/area/liberty/bonfire/forge)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating/under,
+/area/liberty/maintenance/undergroundfloor1east)
 "ahs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera/network/engineering{
@@ -904,8 +889,17 @@
 /turf/simulated/floor/wood/wild3,
 /area/liberty/crew_quarters)
 "alX" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/wall/church_reinforced,
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/obj/structure/mirror{
+	pixel_x = 28
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/vectorrooms)
 "amk" = (
 /obj/structure/sign/department/medbay{
@@ -1002,13 +996,9 @@
 /turf/simulated/floor/tiled/steel,
 /area/liberty/security/range)
 "anb" = (
-/obj/effect/floor_decal/spline/fancy{
-	dir = 4
-	},
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
-/area/liberty/bonfire/forge)
+/obj/structure/bed/chair/sofa/black/right,
+/turf/simulated/floor/tiled/dark,
+/area/liberty/bonfire/vectorrooms)
 "ang" = (
 /obj/random/traps/low_chance,
 /turf/simulated/mineral/planet,
@@ -1033,15 +1023,6 @@
 /obj/effect/floor_decal/industrial/box,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/liberty/engineering/atmos)
-"ans" = (
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 4
-	},
-/obj/structure/decor_light/wallcandle{
-	pixel_y = -32
-	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/liberty/command/prime)
 "anu" = (
 /obj/structure/closet/wardrobe/misc/pjs,
 /obj/item/clothing/under/medigown,
@@ -1112,7 +1093,7 @@
 	pixel_x = 28
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "aoi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -1416,13 +1397,8 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/obj/effect/floor_decal/spline/fancy{
-	dir = 9
-	},
-/obj/structure/decor_edvard_statue,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "arj" = (
 /obj/structure/filingcabinet/filingcabinet,
@@ -1475,10 +1451,6 @@
 /obj/random/material/low_chance,
 /turf/simulated/floor/tiled/dark,
 /area/liberty/rnd/research)
-"arE" = (
-/obj/machinery/petrel_maker,
-/turf/simulated/floor/tiled/steel/techfloor,
-/area/liberty/engineering/engine_room)
 "arH" = (
 /obj/structure/table/rack/shelf,
 /obj/random/material_resources/low_chance,
@@ -2112,30 +2084,13 @@
 /turf/simulated/floor/wood/wild4,
 /area/liberty/dungeon/outside/hunter_cabin)
 "azE" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 8
-	},
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 1
-	},
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 9
-	},
-/obj/effect/floor_decal/border/carpet/black,
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 10
-	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "azP" = (
 /obj/machinery/light{
@@ -2324,16 +2279,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/liberty/security/detectives_office)
-"aBP" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/liberty/bonfire/vectorrooms)
 "aBU" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/blast/shutters{
@@ -2641,10 +2586,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/liberty/medical/genetics_cloning)
-"aFA" = (
-/obj/machinery/recharge_station,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/liberty/bonfire/vectorrooms)
 "aFD" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/flora/ausbushes/sunnybush,
@@ -2727,12 +2668,9 @@
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/liberty/maintenance/oldarmory)
 "aGI" = (
-/obj/structure/table/bench/steel,
-/obj/machinery/camera/network/fontaine{
-	dir = 1
-	},
+/obj/structure/table/steel_reinforced,
 /turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "aGJ" = (
 /obj/effect/floor_decal/industrial/loading/white,
 /obj/effect/decal/cleanable/dirt,
@@ -2985,11 +2923,6 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/asteroid/grass,
 /area/liberty/security/mess_hall)
-"aJD" = (
-/obj/structure/table/rack/shelf,
-/obj/random/gun_normal/low_chance,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
 "aJE" = (
 /obj/structure/table/gamblingtable,
 /obj/random/contraband/low_chance,
@@ -3159,9 +3092,7 @@
 	dir = 1;
 	pixel_y = -32
 	},
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/bioreactor)
 "aLb" = (
 /obj/structure/table/rack/shelf,
@@ -3187,13 +3118,12 @@
 /area/liberty/maintenance/undergroundfloor3north)
 "aLz" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/reagent_dispensers/cahorsbarrel,
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled/dark/golden,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/storage)
 "aLB" = (
 /obj/structure/flora/small/snow/rock2,
@@ -3257,9 +3187,11 @@
 /turf/simulated/floor/tiled/steel,
 /area/liberty/quartermaster/office)
 "aLS" = (
-/obj/structure/closet/secure_closet/personal/trapper,
+/obj/structure/table/rack/shelf,
+/obj/random/material/low_chance,
+/obj/random/material/low_chance,
 /turf/simulated/floor/tiled/steel/brown_perforated,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "aLU" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -3298,19 +3230,10 @@
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/liberty/command/bridge)
 "aMj" = (
-/obj/effect/floor_decal/spline/fancy{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/obj/effect/floor_decal/spline/plain/corner{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "aMo" = (
 /obj/effect/floor_decal/spline/fancy,
@@ -3372,9 +3295,7 @@
 /obj/effect/floor_decal/spline/fancy/corner{
 	dir = 4
 	},
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "aMZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -3463,20 +3384,6 @@
 /obj/structure/scrap/medical/large,
 /turf/simulated/floor/rock,
 /area/liberty/outside/dcave)
-"aNZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/spline/fancy/corner{
-	dir = 1
-	},
-/obj/effect/floor_decal/spline/fancy/corner,
-/turf/simulated/floor/industrial/greybricks,
-/area/liberty/bonfire/stronghold)
 "aOb" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
@@ -3490,36 +3397,23 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/spline/plain/corner{
-	dir = 8
-	},
-/obj/effect/floor_decal/spline/fancy/corner,
-/obj/effect/floor_decal/spline/fancy/corner{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "aOt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/turf/simulated/floor/plating/under,
+/area/liberty/maintenance/undergroundfloor1east)
 "aOE" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -3546,12 +3440,9 @@
 /turf/simulated/wall/r_wall,
 /area/liberty/security/detectives_office)
 "aOV" = (
-/obj/structure/closet/enkindled,
-/obj/structure/decor_light/wallcandle{
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/steel/golden,
-/area/liberty/bonfire/office)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/mineral,
+/area/colony)
 "aPd" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 4
@@ -3603,9 +3494,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/storage)
 "aPB" = (
 /obj/structure/catwalk,
@@ -3932,7 +3821,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "aSC" = (
 /obj/machinery/light{
 	dir = 8
@@ -4255,15 +4144,6 @@
 /obj/effect/floor_decal/industrial/danger,
 /turf/simulated/floor/reinforced,
 /area/shuttle/vasiliy_shuttle_area)
-"aXn" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
 "aXr" = (
 /obj/structure/table/woodentable,
 /obj/machinery/vending/plushies{
@@ -4295,13 +4175,6 @@
 	},
 /turf/simulated/floor/tiled/white/techfloor_grid,
 /area/liberty/security/prisoncells)
-"aXH" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/table/rack,
-/obj/item/storage/toolbox/electrical,
-/obj/item/storage/toolbox/electrical,
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/forge)
 "aXN" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 28
@@ -4337,15 +4210,12 @@
 /obj/item/stack/material/cardboard/random,
 /obj/random/material,
 /obj/random/material,
-/obj/random/material,
-/obj/random/material/low_chance,
-/obj/random/material/low_chance,
 /obj/random/material/low_chance,
 /obj/machinery/alarm{
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "aYn" = (
 /obj/machinery/conveyor_switch{
 	id = "disposals grinder"
@@ -4407,9 +4277,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/spline/fancy/corner,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/bioreactor)
 "aZf" = (
 /obj/machinery/light/small{
@@ -4510,13 +4378,6 @@
 /obj/machinery/vending/cola,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/liberty/hallway/surface/section1)
-"baG" = (
-/obj/machinery/conveyor_switch/oneway{
-	id = "bonfire2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/bioreactor)
 "baJ" = (
 /obj/structure/table/steel,
 /obj/random/common_oddities/low_chance,
@@ -4682,7 +4543,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "bcA" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1
@@ -4912,14 +4773,6 @@
 /obj/structure/table/woodentable,
 /turf/simulated/floor/wood,
 /area/liberty/command/swo/quarters)
-"beQ" = (
-/obj/structure/decor_perfect_pillar,
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/bcarpet,
-/area/liberty/bonfire/forge)
 "bfh" = (
 /obj/structure/flora/small/grassb3,
 /turf/simulated/floor/asteroid/grass,
@@ -4983,7 +4836,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/carpet/sblucarpet,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "bfK" = (
 /obj/structure/table/marble,
 /obj/item/reagent_containers/food/drinks/shaker,
@@ -5027,21 +4880,8 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 4
 	},
-/turf/simulated/floor/industrial/greybricks,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
-"bgt" = (
-/obj/structure/bed/chair/wood,
-/obj/effect/floor_decal/border/carpet/red{
-	dir = 1
-	},
-/obj/effect/floor_decal/border/carpet/red{
-	dir = 4
-	},
-/obj/effect/floor_decal/border/carpet/red{
-	dir = 5
-	},
-/turf/simulated/floor/carpet,
-/area/liberty/bonfire/vectorrooms)
 "bgG" = (
 /obj/structure/flora/pottedplant/dead,
 /obj/effect/decal/cleanable/dirt,
@@ -5148,7 +4988,7 @@
 	name = "NOTICE: Dangerous Equipment";
 	pixel_y = 32
 	},
-/turf/simulated/floor/tiled/dark/golden,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/bioreactor)
 "bhq" = (
 /obj/random/closet_maintloot,
@@ -5156,23 +4996,14 @@
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/liberty/maintenance/undergroundfloor2south)
 "bhy" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 4
-	},
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "bhE" = (
 /obj/structure/girder,
@@ -5216,24 +5047,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark/golden,
 /area/liberty/crew_quarters/skyyard)
-"bio" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/landmark/join/start/forgemaster,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
-/area/liberty/bonfire/forge)
 "biz" = (
 /obj/random/flora/wild/low,
 /turf/simulated/floor/snow,
@@ -5293,11 +5106,7 @@
 /obj/structure/mopbucket,
 /obj/item/reagent_containers/glass/bucket,
 /obj/item/mop,
-/obj/item/soap/bonfire,
-/obj/structure/decor_light/wallcandle{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/dark/golden,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/storage)
 "bjj" = (
 /obj/structure/table/marble,
@@ -5517,11 +5326,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/undergroundfloor3east)
-"blG" = (
-/obj/effect/window_lwall_spawn/smartspawn/church,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/liberty/bonfire/storage)
 "blL" = (
 /obj/structure/table/marble,
 /obj/machinery/cooking_with_jane/stove,
@@ -5562,27 +5366,14 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/liberty/hallway/surface/section1)
-"bmh" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white/golden,
-/area/liberty/bonfire/vectorrooms)
 "bml" = (
-/obj/machinery/door/airlock/multi_tile/glass{
-	dir = 2;
-	name = "Shipbreaker Storage";
-	req_access = list(78)
-	},
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/multi_tile/metal/mait{
+	dir = 2
+	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "bmp" = (
 /obj/effect/overlay/water,
 /obj/effect/overlay/water/top,
@@ -5629,15 +5420,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/undergroundfloor2west)
-"bmN" = (
-/obj/effect/floor_decal/spline/fancy{
-	dir = 10
-	},
-/obj/structure/decor_headless_3,
-/turf/simulated/floor/industrial_pristine/greybricks{
-	dir = 1
-	},
-/area/liberty/bonfire/storage)
 "bmQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -5655,11 +5437,7 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/spline/fancy,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/bioreactor)
 "bnj" = (
 /obj/structure/sign/department/conference_room,
@@ -5826,20 +5604,6 @@
 /obj/item/book/manual/security_space_law,
 /turf/simulated/floor/wood,
 /area/liberty/command/swo/quarters)
-"boT" = (
-/obj/structure/railing/grey{
-	dir = 4
-	},
-/obj/structure/table/rack,
-/obj/effect/floor_decal/wood/tatami{
-	dir = 4
-	},
-/obj/item/melee_training/foil,
-/obj/item/melee_training/foil,
-/obj/item/melee_training/sword,
-/obj/item/melee_training/sword,
-/turf/simulated/floor/wood/tatami,
-/area/liberty/bonfire/stronghold)
 "bpb" = (
 /obj/machinery/door/airlock/vault{
 	name = "Skylight Vault";
@@ -6022,14 +5786,13 @@
 /turf/simulated/floor/rock,
 /area/liberty/maintenance/oldlibrary)
 "brb" = (
-/obj/machinery/door/airlock/silver{
-	req_access = list(27);
-	name = "Unisex Bathrooms"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/wood,
+/obj/machinery/door/airlock/maintenance_common{
+	req_access = list(12)
+	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/vectorrooms)
 "brc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -6508,18 +6271,6 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/liberty/storage/primary)
-"bxs" = (
-/obj/structure/sink{
-	density = 1;
-	desc = "A small fountain of polished stone and has a small pump at the bottom that helps push fresh water.";
-	icon_state = "BaptismFont_Water";
-	name = "Water Fountain"
-	},
-/obj/structure/decor_light/wallcandle{
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/white/golden,
-/area/liberty/bonfire/forge)
 "bxA" = (
 /obj/effect/window_lwall_spawn/smartspawn,
 /turf/simulated/floor/plating,
@@ -6735,10 +6486,6 @@
 	dir = 4
 	},
 /area/liberty/hallway/surface/section1)
-"bAb" = (
-/obj/structure/flora/ausbushes/grassybush,
-/turf/simulated/floor/asteroid/grass,
-/area/liberty/bonfire/stronghold)
 "bAe" = (
 /obj/random/material_ore,
 /turf/simulated/mineral/planet,
@@ -6788,19 +6535,6 @@
 /obj/item/trash/cigbutt,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/liberty/maintenance/oldarmory)
-"bAQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/spline/plain{
-	dir = 8
-	},
-/obj/structure/table/bench/wooden,
-/obj/effect/floor_decal/spline/fancy{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks,
-/area/liberty/bonfire/stronghold)
 "bAS" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 6
@@ -7262,8 +6996,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/turf/simulated/floor/plating/under,
+/area/liberty/maintenance/undergroundfloor1east)
 "bGM" = (
 /obj/structure/table/standard,
 /obj/item/storage/box/bodybags,
@@ -7375,8 +7109,9 @@
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1
 	},
-/turf/simulated/floor/wood/wild3,
-/area/liberty/pros/foreman)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/liberty/maintenance/undergroundfloor1east)
 "bHL" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -7518,14 +7253,16 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/liberty/crew_quarters/sleep/cryo2)
 "bIN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/structure/disposalpipe/segment{
+	dir = 8
 	},
-/turf/simulated/floor/wood,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/vectorrooms)
 "bIO" = (
 /obj/machinery/door/airlock/maintenance_common,
@@ -7960,16 +7697,11 @@
 /turf/simulated/floor/carpet/turcarpet,
 /area/liberty/command/cso)
 "bNZ" = (
-/obj/structure/table/rack,
-/obj/effect/floor_decal/industrial/warningwhite/full,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/camera/network/fontaine{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "bOa" = (
 /obj/item/tank/emergency_oxygen/double,
 /obj/item/tank/emergency_oxygen/double,
@@ -7993,9 +7725,9 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/network/fontaine,
-/turf/simulated/floor/carpet,
-/area/liberty/pros/foreman)
+/obj/item/storage/firstaid/outsider,
+/turf/simulated/floor/plating/under,
+/area/liberty/maintenance/undergroundfloor1east)
 "bOg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -8221,9 +7953,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/unary/vent_pump,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "bQm" = (
 /obj/effect/decal/cleanable/dirt,
@@ -8265,11 +7995,9 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/undergroundfloor2west)
 "bRd" = (
-/obj/machinery/spicebed,
-/turf/simulated/floor/industrial_pristine/greybricks{
-	dir = 1
-	},
-/area/liberty/bonfire/alchemist)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating/under,
+/area/liberty/bonfire/vectorrooms)
 "bRf" = (
 /obj/effect/floor_decal/industrial/warningred,
 /obj/item/stool/padded,
@@ -8367,8 +8095,8 @@
 "bSb" = (
 /obj/structure/table/standard,
 /obj/machinery/recharger,
-/turf/simulated/floor/tiled/steel/brown_perforated,
-/area/liberty/pros/foreman)
+/turf/simulated/floor/plating/under,
+/area/liberty/maintenance/undergroundfloor1east)
 "bSc" = (
 /obj/random/traps/low_chance,
 /turf/simulated/floor/tiled/white/gray_perforated,
@@ -8679,12 +8407,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/liberty/maintenance/undergroundfloor3south)
-"bUR" = (
-/obj/item/modular_computer/console/preset/trade{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/liberty/crew_quarters/hydroponics)
 "bVa" = (
 /obj/random/closet_maintloot,
 /obj/effect/decal/cleanable/dirt,
@@ -8761,7 +8483,7 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 4
 	},
-/turf/simulated/floor/industrial/greybricks,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "bVK" = (
 /obj/effect/floor_decal/industrial/outline/red,
@@ -8965,16 +8687,11 @@
 	dir = 4;
 	icon_state = "pipe-j2"
 	},
-/obj/effect/floor_decal/spline/fancy{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "bYg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -9018,12 +8735,6 @@
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/liberty/rnd/lab)
-"bYC" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
-/area/liberty/bonfire/bioreactor)
 "bYE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/rubble,
@@ -9327,20 +9038,7 @@
 /obj/effect/window_lwall_spawn/reinforced,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating/under,
-/area/liberty/pros/foreman)
-"cby" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/landmark/join/start/forgemaster,
-/obj/effect/floor_decal/spline/fancy,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
-/area/liberty/bonfire/office)
+/area/liberty/maintenance/undergroundfloor1east)
 "cbA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 1
@@ -9428,10 +9126,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/liberty/quartermaster/office)
-"ccl" = (
-/obj/structure/table/woodentable,
-/turf/simulated/floor/tiled/steel/golden,
-/area/liberty/bonfire/office)
 "ccq" = (
 /obj/structure/table/standard,
 /obj/item/newspaper,
@@ -9461,7 +9155,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "ccC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -9504,12 +9198,9 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/liberty/quartermaster/hangarsupply)
 "ccQ" = (
-/obj/structure/closet/forgemaster,
-/obj/structure/decor_light/wallcandle{
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/steel/golden,
-/area/liberty/bonfire/office)
+/obj/landmark/join/start/oathpledge,
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/liberty/pros/shuttle)
 "cdn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -9792,20 +9483,6 @@
 /obj/item/cell/medium,
 /turf/simulated/floor/tiled/steel,
 /area/liberty/quartermaster/miningdock)
-"cgx" = (
-/obj/machinery/camera/network/custodians{
-	dir = 1
-	},
-/obj/effect/floor_decal/spline/fancy,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/table/bench/wooden,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
-/area/liberty/bonfire/stronghold)
 "cgz" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/tiled/white/gray_platform,
@@ -9903,20 +9580,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/computer/guestpass{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/spline/plain{
-	dir = 8
-	},
-/obj/effect/floor_decal/spline/fancy{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "chN" = (
 /obj/effect/decal/cleanable/dirt,
@@ -10004,11 +9670,6 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/liberty/security/maingate_outside)
-"ciF" = (
-/obj/effect/window_lwall_spawn/smartspawn/church,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/liberty/bonfire/forge)
 "ciJ" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -10087,9 +9748,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "cjU" = (
 /obj/machinery/vending/wallmed{
@@ -10100,8 +9759,8 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood/wild3,
-/area/liberty/pros/foreman)
+/turf/simulated/floor/plating/under,
+/area/liberty/maintenance/undergroundfloor1east)
 "cjV" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -10110,12 +9769,11 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/liberty/rnd/lab)
 "ckk" = (
-/obj/machinery/power/torchbearer,
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -32
 	},
-/turf/simulated/floor/tiled/dark/techfloor_grid,
+/turf/simulated/floor/wood/wild1,
 /area/liberty/hallway/surface/section1)
 "ckl" = (
 /obj/machinery/conveyor/east{
@@ -10706,7 +10364,8 @@
 /turf/simulated/mineral,
 /area/liberty/outside/forest)
 "cqx" = (
-/obj/effect/window_lwall_spawn/smartspawn/church,
+/obj/effect/window_lwall_spawn/reinforced,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/liberty/bonfire/stronghold)
 "cqE" = (
@@ -10744,7 +10403,7 @@
 /obj/structure/table/steel,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "crh" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -11038,13 +10697,7 @@
 /turf/simulated/floor/rock/manmade/concrete,
 /area/liberty/maintenance/undergroundfloor2north)
 "cuz" = (
-/obj/effect/floor_decal/spline/fancy{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/bioreactor)
 "cuC" = (
 /obj/item/modular_computer/console/preset/engineering/shield,
@@ -11165,15 +10818,6 @@
 /obj/landmark/join/start/mining,
 /turf/simulated/floor/tiled/steel,
 /area/liberty/quartermaster/miningdock)
-"cwa" = (
-/obj/effect/floor_decal/spline/fancy{
-	dir = 10
-	},
-/obj/structure/decor_spark_statue,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
-/area/liberty/bonfire/stronghold)
 "cwc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -11197,10 +10841,13 @@
 /turf/simulated/floor/tiled/steel,
 /area/liberty/crew_quarters/toilet)
 "cwg" = (
-/obj/random/mecha/low_chance,
-/obj/machinery/mech_recharger,
-/turf/simulated/floor/plating,
-/area/liberty/rnd/robotics)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/liberty/bonfire/stronghold)
 "cwh" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/carpet/turcarpet,
@@ -11358,19 +11005,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/effect/floor_decal/spline/fancy/corner{
-	dir = 4
-	},
-/obj/effect/floor_decal/spline/fancy/corner{
-	dir = 8
-	},
-/turf/simulated/floor/industrial/greybricks,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "cxw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -11517,7 +11158,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "czs" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -11551,14 +11192,22 @@
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/liberty/pros/shuttle)
 "czH" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood/wild3,
-/area/liberty/command/prime)
+/obj/effect/floor_decal/border/carpet/black{
+	dir = 4
+	},
+/obj/effect/floor_decal/border/carpet/black{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/liberty/bonfire/stronghold)
 "czI" = (
 /obj/structure/shuttle_part/science{
 	icon_state = "10,20"
@@ -11602,8 +11251,9 @@
 /area/shuttle/vasiliy_shuttle_area)
 "cAq" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/random/cluster/spiders,
 /turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "cAr" = (
 /obj/structure/shuttle_part/escpod{
 	icon_state = "escpodwall9";
@@ -11611,16 +11261,6 @@
 	},
 /turf/simulated/floor/tiled/dark/cargo,
 /area/shuttle/surface_transport_lz)
-"cAx" = (
-/obj/structure/bed/chair/wood{
-	dir = 1;
-	tag = "icon-wooden_chair (NORTH)"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/border/carpet/red,
-/obj/landmark/join/start/oathbound,
-/turf/simulated/floor/carpet,
-/area/liberty/bonfire/vectorrooms)
 "cAF" = (
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -11669,11 +11309,6 @@
 	},
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/liberty/hallway/surface/section1)
-"cBk" = (
-/obj/machinery/trade_beacon/sending,
-/obj/effect/floor_decal/industrial/outline/blue,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/liberty/crew_quarters/hydroponics)
 "cBs" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -11698,7 +11333,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "cBw" = (
 /obj/machinery/door/airlock/centcom{
 	id_tag = "F1-A1";
@@ -11753,7 +11388,7 @@
 	name = "Church Foyer"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood/wild3,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "cBT" = (
 /obj/structure/closet/crate/hydroponics,
@@ -11932,9 +11567,7 @@
 /obj/effect/floor_decal/spline/fancy/corner{
 	dir = 8
 	},
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark/golden,
 /area/liberty/bonfire/vectorrooms)
 "cEy" = (
 /obj/structure/bed/chair/office/light,
@@ -12052,14 +11685,6 @@
 	name = "murky water"
 	},
 /area/liberty/maintenance/undergroundfloor3south)
-"cFH" = (
-/obj/structure/railing/grey,
-/obj/effect/floor_decal/wood/tatami,
-/obj/structure/railing/grey{
-	dir = 4
-	},
-/turf/simulated/floor/wood/tatami,
-/area/liberty/bonfire/stronghold)
 "cFV" = (
 /turf/simulated/shuttle/wall/science{
 	icon_state = "10,1"
@@ -12072,10 +11697,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/spline/fancy{
-	dir = 8
-	},
-/turf/simulated/floor/industrial/greybricks,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "cGb" = (
 /obj/structure/cable/green{
@@ -12277,9 +11899,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/storage)
 "cHP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -12435,18 +12055,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/liberty/crew_quarters/hotsprings)
-"cJC" = (
-/obj/structure/toilet,
-/obj/effect/floor_decal/steeldecal/steel_decals10{
-	dir = 10
-	},
-/obj/structure/decor_light/wallcandle{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4
-	},
-/area/liberty/bonfire/vectorrooms)
 "cJH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -12849,15 +12457,10 @@
 	dir = 1;
 	frequency = 1441;
 	name = "Tank Monitor";
-	sensors = list("n2_sensor"="Nitrogen","o2_sensor"="Oxygen","co2_sensor"="Carbon    Dioxide","tox_sensor"="Toxins","n2o_sensor"="Nitrous    Oxide","waste_sensor"="Gas    Mix    Tank")
+	sensors = list("n2_sensor"="Nitrogen","o2_sensor"="Oxygen","co2_sensor"="Carbon        Dioxide","tox_sensor"="Toxins","n2o_sensor"="Nitrous        Oxide","waste_sensor"="Gas        Mix        Tank")
 	},
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/liberty/engineering/atmos/surface)
-"cNZ" = (
-/obj/item/stool,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/brown_platform,
-/area/liberty/pros/prep)
 "cOr" = (
 /obj/structure/boulder,
 /turf/simulated/floor/snow,
@@ -12889,12 +12492,9 @@
 /area/liberty/rnd/xenobiology)
 "cOF" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/computer/guestpass{
-	pixel_y = -32
-	},
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "cOI" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -13171,9 +12771,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark/golden,
 /area/liberty/bonfire/vectorrooms)
 "cSb" = (
 /obj/structure/closet/wall_mounted/emcloset{
@@ -13261,20 +12859,13 @@
 /turf/simulated/floor/tiled/steel,
 /area/liberty/engineering/engine_room)
 "cSK" = (
-/obj/structure/decor_light/wallcandle{
-	pixel_y = -32
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
-/obj/machinery/portable_atmospherics/hydroponics/soil,
-/obj/effect/floor_decal/spline/grass_edge{
-	dir = 1
-	},
-/obj/item/spice_plant/cinnamon,
-/obj/item/spice_plant/cumin,
-/obj/item/spice_plant/gourd,
-/obj/item/spice_plant/lilyflower,
-/obj/item/spice_plant/spikenard,
-/turf/simulated/floor/asteroid/dirt/flood/plough,
-/area/liberty/bonfire/alchemist)
+/obj/machinery/disposal,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/liberty/bonfire/vectorrooms)
 "cSP" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /obj/machinery/door/blast/regular/open{
@@ -13283,7 +12874,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark/gray_platform,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "cSU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/wall/r_wall,
@@ -13310,7 +12901,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/wall/r_wall,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "cTs" = (
 /turf/simulated/floor/tiled/white/cargo,
 /area/liberty/rnd/robotics)
@@ -13607,15 +13198,8 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/floor_decal/spline/fancy{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/spline/plain{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "cWJ" = (
 /obj/structure/bed/chair{
@@ -13643,8 +13227,9 @@
 /turf/simulated/floor/wood,
 /area/liberty/command/merchant)
 "cWY" = (
+/obj/structure/sign/medsci/firstaidstation,
 /turf/simulated/wall/r_wall,
-/area/liberty/pros/foreman)
+/area/liberty/maintenance/undergroundfloor1east)
 "cXf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/steel,
@@ -13665,12 +13250,6 @@
 "cXs" = (
 /turf/simulated/floor/carpet/bcarpet,
 /area/liberty/maintenance/oldlibrary)
-"cXu" = (
-/obj/effect/floor_decal/wood/tatami{
-	dir = 4
-	},
-/turf/simulated/floor/wood/tatami,
-/area/liberty/bonfire/stronghold)
 "cXw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
@@ -13743,7 +13322,7 @@
 /obj/machinery/microwave,
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/white/techfloor_grid,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "cYs" = (
 /obj/structure/lattice,
 /obj/machinery/newscaster{
@@ -14012,9 +13591,10 @@
 	},
 /obj/machinery/air_stopper,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
+/obj/machinery/door/airlock/maintenance_common{
+	req_access = list(12)
 	},
+/turf/simulated/floor/tiled/dark/golden,
 /area/liberty/bonfire/vectorrooms)
 "daA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -14026,7 +13606,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "daI" = (
 /obj/structure/curtain/open/shower,
 /obj/effect/decal/cleanable/dirt,
@@ -14435,12 +14015,6 @@
 /obj/structure/closet/jcloset,
 /turf/simulated/floor/tiled/steel/monofloor,
 /area/liberty/crew_quarters/janitor)
-"dep" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 8
-	},
-/turf/simulated/floor/wood/wild3,
-/area/liberty/command/prime)
 "dex" = (
 /obj/structure/flora/small/grassa5,
 /turf/simulated/floor/asteroid/grass,
@@ -14493,20 +14067,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/liberty/medical/cryo)
-"deQ" = (
-/obj/structure/railing/grey{
-	dir = 4
-	},
-/obj/structure/table/rack,
-/obj/effect/floor_decal/wood/tatami{
-	dir = 4
-	},
-/obj/item/melee_training/axe,
-/obj/item/melee_training/axe,
-/obj/item/melee_training/axe,
-/obj/item/melee_training/axe,
-/turf/simulated/floor/wood/tatami,
-/area/liberty/bonfire/stronghold)
 "deW" = (
 /obj/machinery/recharge_station,
 /turf/simulated/floor/tiled/steel,
@@ -14723,9 +14283,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/storage)
 "dhb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -14793,7 +14351,7 @@
 "dhH" = (
 /obj/machinery/light/floor,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/techfloor_grid,
+/turf/simulated/floor/tiled/dark/gray_platform,
 /area/liberty/crew_quarters/hydroponics)
 "dhM" = (
 /turf/simulated/floor/industrial/navy_slates,
@@ -15065,9 +14623,7 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
 	},
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark/golden,
 /area/liberty/bonfire/vectorrooms)
 "djU" = (
 /obj/structure/table/standard,
@@ -15469,8 +15025,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/turf/simulated/floor/wood/wild3,
-/area/liberty/pros/foreman)
+/turf/simulated/floor/plating/under,
+/area/liberty/maintenance/undergroundfloor1east)
 "dpe" = (
 /obj/structure/table/standard,
 /obj/item/paper_bin{
@@ -15533,9 +15089,9 @@
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/liberty/engineering/atmos/surface)
 "dqg" = (
-/obj/machinery/vending/containers,
+/obj/structure/closet/crate/trashcart,
 /turf/simulated/floor/tiled/steel/brown_perforated,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "dqi" = (
 /obj/structure/table/standard,
 /obj/item/device/lighting/toggleable/flashlight/pen{
@@ -15943,26 +15499,6 @@
 "dwp" = (
 /turf/simulated/mineral,
 /area/liberty/outside/inside_colony)
-"dwr" = (
-/obj/structure/closet/wall_mounted/emcloset{
-	pixel_x = 32
-	},
-/obj/effect/floor_decal/industrial/warningwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 1
-	},
-/obj/effect/floor_decal/spline/fancy{
-	dir = 5
-	},
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
-/area/liberty/bonfire/forge)
 "dws" = (
 /obj/machinery/door/airlock/glass_security{
 	name = "Security Post";
@@ -16017,22 +15553,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/liberty/pros/shuttle)
 "dxd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/camera/network/custodians{
+/obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/machinery/holoposter{
-	pixel_x = -32
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/wood,
+/obj/machinery/disposal,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/vectorrooms)
 "dxi" = (
 /obj/effect/decal/cleanable/dirt,
@@ -16156,11 +15681,6 @@
 	},
 /turf/simulated/floor/snow,
 /area/liberty/outside/inside_colony)
-"dyF" = (
-/obj/structure/table/woodentable,
-/obj/item/storage/firstaid/nt,
-/turf/simulated/floor/wood,
-/area/liberty/bonfire/vectorrooms)
 "dyN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -16232,9 +15752,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/dark/cargo,
 /area/liberty/security/maingate)
-"dzz" = (
-/turf/simulated/wall/church_reinforced,
-/area/liberty/bonfire/forge)
 "dzC" = (
 /obj/structure/scrap/poor/large,
 /turf/simulated/floor/tiled/techmaint,
@@ -16285,13 +15802,8 @@
 /obj/random/booze/low_chance,
 /obj/random/booze/low_chance,
 /obj/random/booze/low_chance,
-/obj/random/booze/low_chance,
-/obj/random/booze/low_chance,
-/obj/random/booze/low_chance,
-/obj/random/booze/low_chance,
-/obj/random/booze/low_chance,
 /turf/simulated/floor/tiled/white/techfloor_grid,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "dzQ" = (
 /obj/effect/floor_decal/industrial/warningred{
 	dir = 1
@@ -16372,7 +15884,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "dAK" = (
 /obj/structure/bed/chair/wood{
 	dir = 4
@@ -16406,10 +15918,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/liberty/security/main)
-"dBc" = (
-/obj/structure/flora/ausbushes/leafybush,
-/turf/simulated/floor/asteroid/grass,
-/area/liberty/bonfire/stronghold)
 "dBj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -16555,20 +16063,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/liberty/rnd/lab)
-"dDi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 1
-	},
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 8
-	},
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/bcarpet,
-/area/liberty/bonfire/forge)
 "dDp" = (
 /obj/random/flora/small_jungle_tree,
 /turf/simulated/floor/asteroid/grass,
@@ -16606,7 +16100,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/carpet/sblucarpet,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "dDR" = (
 /obj/machinery/light{
 	dir = 1
@@ -16619,11 +16113,7 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
 	},
-/obj/effect/floor_decal/spline/fancy,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/bioreactor)
 "dDU" = (
 /obj/effect/floor_decal/industrial/stand_clear/white{
@@ -16835,9 +16325,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1
 	},
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/bioreactor)
 "dGr" = (
 /obj/effect/decal/cleanable/dirt,
@@ -16900,7 +16388,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild1,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "dHp" = (
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics";
@@ -17410,15 +16898,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/liberty/hallway/surface/section1)
-"dMJ" = (
-/obj/effect/floor_decal/spline/fancy{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
-/area/liberty/bonfire/stronghold)
 "dMK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/mob/spiders/low_chance,
@@ -17615,14 +17094,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/substation/sec)
-"dOW" = (
-/obj/effect/window_lwall_spawn/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/blast/regular{
-	id = "ProspShop"
-	},
-/turf/simulated/floor/plating/under,
-/area/liberty/pros/prep)
 "dOY" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
@@ -17681,49 +17152,18 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/spline/fancy{
-	dir = 4
-	},
 /obj/effect/floor_decal/spline/fancy/corner{
 	dir = 4
 	},
-/obj/effect/floor_decal/spline/fancy/corner{
-	dir = 8
-	},
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 8
-	},
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 4
-	},
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 5
-	},
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 9
-	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/bioreactor)
 "dPI" = (
-/obj/machinery/door/firedoor,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/window/reinforced,
+/obj/structure/bed/chair/sofa/black{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/bonfire{
-	name = "Brewing Room"
-	},
-/turf/simulated/floor/wood,
-/area/liberty/bonfire/alchemist)
+/turf/simulated/floor/tiled/dark,
+/area/liberty/bonfire/vectorrooms)
 "dPJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -17744,16 +17184,11 @@
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/liberty/command/meeting_room)
 "dPR" = (
-/obj/structure/decor_light/wallcandle{
-	pixel_x = -32
-	},
-/obj/effect/floor_decal/spline/fancy,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/golden,
 /area/liberty/bonfire/storage)
 "dPY" = (
@@ -18037,10 +17472,6 @@
 /obj/random/scrap/dense_weighted,
 /turf/simulated/floor/rock/alt,
 /area/liberty/maintenance/maint_merc)
-"dTC" = (
-/obj/machinery/multistructure/bonfire_part/scorchtank_platform,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/liberty/bonfire/bioreactor)
 "dTD" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
@@ -18250,9 +17681,7 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
 	},
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "dVY" = (
 /obj/machinery/light/small,
@@ -18262,14 +17691,6 @@
 /obj/item/mecha_parts/mecha_tracking,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/liberty/maintenance/undergroundfloor2south)
-"dWg" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/palebush,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/liberty/bonfire/stronghold)
 "dWh" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
@@ -18634,11 +18055,6 @@
 /turf/simulated/floor/tiled/steel/monofloor,
 /area/liberty/command/tcommsat/computer)
 "ebk" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "North APC";
-	pixel_y = 28
-	},
 /obj/structure/cable/green{
 	d2 = 4;
 	icon_state = "0-4"
@@ -18646,11 +18062,11 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 9
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/spline/fancy/corner,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
+/obj/machinery/power/apc/inactive{
+	name = "North APC";
+	pixel_y = 28
 	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/bioreactor)
 "ebA" = (
 /obj/structure/table/steel_reinforced,
@@ -18738,12 +18154,10 @@
 /turf/simulated/floor/wood/wild5,
 /area/liberty/maintenance/undergroundfloor1oldgarden)
 "ecH" = (
-/obj/structure/closet/oathbound,
-/obj/structure/decor_light/wallcandle{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/steel/golden,
-/area/liberty/bonfire/office)
+/obj/machinery/door/firedoor,
+/obj/effect/window_lwall_spawn/smartspawn,
+/turf/simulated/floor/plating,
+/area/liberty/bonfire/bioreactor)
 "ecI" = (
 /obj/structure/table/standard,
 /obj/item/device/lighting/toggleable/lamp,
@@ -18859,9 +18273,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark/golden,
 /area/liberty/bonfire/vectorrooms)
 "eeB" = (
 /obj/machinery/atmospherics/unary/vent_scrubber,
@@ -18934,14 +18346,6 @@
 	},
 /turf/simulated/floor/wood/wild1,
 /area/liberty/crew_quarters/dorm1)
-"efZ" = (
-/obj/structure/table/woodentable,
-/obj/structure/reagent_dispensers/cahorsbarrel,
-/obj/item/reagent_containers/food/drinks/drinkingglass/wineglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass/wineglass,
-/obj/effect/floor_decal/border/carpet/red,
-/turf/simulated/floor/carpet,
-/area/liberty/bonfire/stronghold)
 "ege" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -19022,7 +18426,7 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 8
 	},
-/turf/simulated/floor/industrial/greybricks,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "ehf" = (
 /obj/effect/decal/cleanable/dirt,
@@ -19166,14 +18570,13 @@
 /turf/simulated/floor/plating/under,
 /area/liberty/maintenance/undergroundfloor2east)
 "eiX" = (
-/obj/machinery/door/airlock/mining{
-	name = "Fontaine Prep";
-	req_access = list(78)
-	},
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/maintenance_common{
+	req_access = list(12)
+	},
 /turf/simulated/floor/tiled/steel/brown_perforated,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "eji" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -19228,10 +18631,6 @@
 "ejs" = (
 /turf/simulated/floor/wood/wild2,
 /area/liberty/crew_quarters/hotsprings)
-"ejt" = (
-/obj/structure/sign/faction/custodians,
-/turf/simulated/wall/church_reinforced,
-/area/liberty/bonfire/stronghold)
 "eju" = (
 /obj/structure/flora/tree/snow/three,
 /obj/structure/flora/small/snow/rock7,
@@ -19244,15 +18643,6 @@
 /obj/item/modular_computer/console/preset/engineering/rcon,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/liberty/engineering/shield_generator)
-"ejA" = (
-/obj/structure/table/woodentable,
-/obj/item/paper_bin,
-/obj/item/storage/fancy/crayons,
-/obj/item/storage/fancy/crayons,
-/obj/item/pen,
-/obj/item/hand_labeler,
-/turf/simulated/floor/wood,
-/area/liberty/bonfire/vectorrooms)
 "ejC" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 8
@@ -19668,13 +19058,13 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/liberty/quartermaster/disposaldrop)
 "enI" = (
-/obj/machinery/door/airlock{
-	name = "Bathroom"
-	},
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/maintenance_common{
+	req_access = list(12)
+	},
 /turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "enP" = (
 /obj/machinery/recharge_station,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -19769,7 +19159,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "epa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/industrial/arrows/white{
@@ -19778,9 +19168,10 @@
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/liberty/security/interrogation)
 "epd" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/turf/simulated/floor/tiled/steel/brown_perforated,
-/area/liberty/pros/foreman)
+/obj/effect/decal/cleanable/dirt,
+/obj/random/firstaid,
+/turf/simulated/floor/tiled/dark,
+/area/liberty/maintenance/undergroundfloor1east)
 "epj" = (
 /obj/structure/flora/small/grassa4,
 /turf/simulated/floor/asteroid/grass,
@@ -19798,18 +19189,11 @@
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/liberty/quartermaster/office)
 "epz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
+/obj/structure/window/reinforced,
+/obj/structure/bed/chair/sofa/black/right{
+	dir = 1
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/vectorrooms)
 "epC" = (
 /obj/random/mob/vox/low_chance,
@@ -19996,16 +19380,6 @@
 /obj/structure/table/woodentable,
 /turf/simulated/floor/carpet/turcarpet,
 /area/liberty/command/captain/quarters)
-"esw" = (
-/obj/machinery/computer/arcade,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor/wood,
-/area/liberty/bonfire/vectorrooms)
 "esz" = (
 /obj/structure/bed/chair/comfy/brown,
 /obj/structure/catwalk,
@@ -20110,11 +19484,6 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/liberty/security/mess_hall)
-"etC" = (
-/obj/structure/table/woodentable,
-/obj/random/toy/plushie,
-/turf/simulated/floor/carpet,
-/area/liberty/bonfire/vectorrooms)
 "etP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/hologram/holopad,
@@ -20165,13 +19534,11 @@
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/liberty/hallway/surface/section1)
 "eux" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/unary/vent_scrubber{
+/obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/structure/decor_light/wallcandle{
-	pixel_y = -32
-	},
+/obj/machinery/disposal,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/liberty/bonfire/vectorrooms)
 "euy" = (
@@ -20317,28 +19684,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/asteroid/grass,
 /area/liberty/crew_quarters/hydroponics)
-"eww" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 1
-	},
-/obj/effect/floor_decal/border/carpet/black,
-/obj/machinery/camera/network/custodians{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/liberty/bonfire/stronghold)
 "ewA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light_switch{
@@ -20398,7 +19743,10 @@
 	name = "Cleaning supplies"
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
+/obj/machinery/door/airlock/maintenance_common{
+	req_access = list(12)
+	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/storage)
 "exE" = (
 /obj/machinery/light{
@@ -20672,17 +20020,6 @@
 /obj/item/pen/blue,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/liberty/medical/genetics)
-"eBu" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
-/area/liberty/bonfire/forge)
 "eBG" = (
 /obj/structure/multiz/stairs/enter/bottom{
 	dir = 8
@@ -21132,13 +20469,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/checker_large,
 /area/liberty/maintenance/oldkitchen)
-"eGI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/noticeboard/church{
-	pixel_y = 32
-	},
-/turf/simulated/floor/wood,
-/area/liberty/bonfire/vectorrooms)
 "eGJ" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -21149,12 +20479,7 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 8
 	},
-/obj/structure/sign/faction/derelict1{
-	desc = "ATTENTION: The Bonfire is a highly dangerous piece of equipment, we recommend caution when using it. Appropiate use of fireproof Custodian voidsuits is paramount to avoid catching fire when operating the equipment and to prevent heavy injuries in the event of Scorch spillage.";
-	name = "NOTICE: Dangerous Equipment";
-	pixel_x = -32
-	},
-/turf/simulated/floor/industrial/greybricks,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "eGK" = (
 /obj/machinery/door/firedoor/multi_tile{
@@ -21290,11 +20615,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/spline/fancy{
-	dir = 8
-	},
-/turf/simulated/floor/industrial/greybricks,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "eIc" = (
 /obj/structure/disposalpipe/segment{
@@ -21497,7 +20818,7 @@
 "eJU" = (
 /obj/structure/table/steel,
 /turf/simulated/floor/tiled/steel/brown_perforated,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "eJZ" = (
 /obj/machinery/holoposter{
 	pixel_y = 32
@@ -21654,7 +20975,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "eLs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood{
@@ -21668,17 +20989,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/spline/fancy{
-	dir = 1
-	},
-/obj/structure/table/bench/wooden,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "eLw" = (
 /obj/structure/disposalpipe/segment,
@@ -21982,14 +21296,6 @@
 	},
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/liberty/hallway/surface/section1)
-"ePf" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/autolathe/artist_bench,
-/obj/structure/decor_light/wallcandle{
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/forge)
 "ePG" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -22026,9 +21332,7 @@
 /obj/machinery/recharger,
 /obj/structure/table/woodentable,
 /obj/effect/floor_decal/spline/fancy,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/bioreactor)
 "ePQ" = (
 /obj/machinery/atmospherics/pipe/zpipe/down,
@@ -22270,16 +21574,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/spline/fancy{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "eTY" = (
 /obj/effect/window_lwall_spawn/reinforced,
@@ -22387,15 +21686,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild1,
 /area/liberty/maintenance/oldlibrary)
-"eVn" = (
-/obj/structure/bed/chair/wood{
-	dir = 1;
-	tag = "icon-wooden_chair (NORTH)"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/border/carpet/red,
-/turf/simulated/floor/carpet,
-/area/liberty/bonfire/vectorrooms)
 "eVq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -22857,16 +22147,11 @@
 	name = "Custodians - Bonfire processing";
 	sortType = "Custodians - Bonfire processing"
 	},
-/obj/effect/floor_decal/spline/fancy{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "fbx" = (
 /obj/structure/bed/chair{
@@ -23265,10 +22550,9 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/undergroundfloor2north)
 "ffy" = (
-/obj/structure/closet/forgemaster,
-/obj/machinery/light,
-/turf/simulated/floor/tiled/steel/golden,
-/area/liberty/bonfire/office)
+/obj/landmark/join/start/enkindled,
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/liberty/pros/shuttle)
 "ffC" = (
 /obj/structure/table/woodentable,
 /obj/item/device/lighting/toggleable/lantern,
@@ -23753,32 +23037,6 @@
 /obj/machinery/vending/build_a_drone,
 /turf/simulated/wall/r_wall,
 /area/liberty/crew_quarters/sleep/cryo2)
-"flu" = (
-/obj/machinery/door/bonfire/secure{
-	name = "Oathpledge Quarters"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/liberty/command/prime)
-"fly" = (
-/obj/effect/floor_decal/spline/fancy{
-	dir = 1
-	},
-/obj/structure/decor_light/beacon,
-/turf/simulated/floor/tiled/dark/panels,
-/area/liberty/bonfire/storage)
 "flC" = (
 /obj/machinery/space_heater,
 /obj/structure/sign/painting/paintingsunset{
@@ -23808,30 +23066,21 @@
 /turf/simulated/floor/tiled/dark,
 /area/liberty/crew_quarters/barbackroom)
 "flI" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/holoposter{
 	pixel_y = -33
 	},
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 1
-	},
-/obj/effect/floor_decal/border/carpet/black,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "flK" = (
 /obj/effect/decal/cleanable/dirt,
@@ -24033,13 +23282,11 @@
 	dir = 1
 	},
 /obj/structure/table/rack/shelf,
-/obj/item/stack/material/glass/random,
-/obj/item/stack/material/glass/random,
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "fnq" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -24109,12 +23356,15 @@
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/liberty/hallway/surface/section1)
 "fnR" = (
-/obj/effect/floor_decal/spline/grass_edge{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/obj/machinery/potionmaker,
-/turf/simulated/floor/asteroid/dirt/flood/plough,
-/area/liberty/bonfire/alchemist)
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/liberty/bonfire/vectorrooms)
 "fnV" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -24425,15 +23675,10 @@
 	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/liberty/hallway/surface/section1)
-"frm" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/suit_storage_unit/nt/flameshield,
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/storage)
 "frp" = (
-/obj/effect/window_lwall_spawn/smartspawn/church,
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/liberty/bonfire/bioreactor)
 "frr" = (
@@ -24614,16 +23859,6 @@
 "ftU" = (
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/liberty/engineering/atmos/storage)
-"ftV" = (
-/obj/random/furniture/pottedplant,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/simulated/floor/wood,
-/area/liberty/bonfire/vectorrooms)
 "fuc" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /obj/effect/decal/cleanable/dirt,
@@ -24763,23 +23998,6 @@
 	},
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/liberty/command/panic_room)
-"fvv" = (
-/obj/machinery/disposal,
-/obj/effect/floor_decal/industrial/box/red,
-/obj/structure/disposalpipe/trunk{
-	dir = 2
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/alarm{
-	pixel_y = 32
-	},
-/turf/simulated/floor/wood,
-/area/liberty/bonfire/vectorrooms)
 "fvx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera/network/colony_underground,
@@ -24949,13 +24167,6 @@
 /obj/machinery/door/airlock/external,
 /turf/simulated/floor/reinforced,
 /area/liberty/maintenance/undergroundfloor2north)
-"fyr" = (
-/obj/effect/floor_decal/steeldecal/steel_decals10{
-	dir = 10
-	},
-/obj/machinery/recharge_station,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/liberty/bonfire/vectorrooms)
 "fyx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc{
@@ -25017,17 +24228,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/spline/plain{
-	dir = 8
-	},
-/obj/effect/floor_decal/spline/fancy{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor/multi_tile{
-	dir = 2
-	},
-/turf/simulated/floor/industrial/greybricks,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "fzb" = (
 /obj/structure/flora/big/bush2,
@@ -25134,7 +24336,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "fAJ" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 5
@@ -25452,15 +24654,6 @@
 /obj/item/trash/tray,
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/undergroundfloor2west)
-"fDZ" = (
-/obj/structure/railing/grey{
-	dir = 8
-	},
-/obj/effect/floor_decal/wood/tatami{
-	dir = 8
-	},
-/turf/simulated/floor/wood/tatami,
-/area/liberty/bonfire/stronghold)
 "fEb" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/tiled/dark/violetcorener,
@@ -25471,11 +24664,6 @@
 /obj/item/remains/unathi,
 /turf/simulated/floor/rock,
 /area/liberty/maintenance/northcave)
-"fEg" = (
-/obj/structure/table/woodentable,
-/obj/item/pen,
-/turf/simulated/floor/carpet,
-/area/liberty/bonfire/vectorrooms)
 "fEh" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /obj/machinery/door/blast/shutters{
@@ -25663,20 +24851,9 @@
 /area/liberty/hallway/side/f2section1)
 "fGB" = (
 /obj/machinery/light,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 4
-	},
-/obj/effect/floor_decal/border/carpet/black,
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 6
-	},
-/obj/effect/floor_decal/border/carpet/black/corner{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "fGD" = (
 /obj/structure/grille/broken,
@@ -25687,11 +24864,9 @@
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/liberty/maintenance/undergroundfloor3north)
 "fGF" = (
-/obj/structure/table/rack/shelf,
-/obj/item/stack/material/steel/random,
-/obj/item/stack/material/steel/random,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/obj/landmark/join/start/shipbreaker,
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/liberty/pros/shuttle)
 "fGG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
@@ -25938,6 +25113,9 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/vending/security{
+	categories = 3
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/liberty/security/tactical)
@@ -26704,23 +25882,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
 /area/liberty/maintenance/undergroundfloor2north)
-"fSn" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/spline/fancy{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
-/area/liberty/bonfire/office)
 "fSo" = (
 /obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor/tiled/dark,
@@ -27381,19 +26542,9 @@
 /turf/simulated/floor/plating/under,
 /area/liberty/maintenance/substation/bridge)
 "fZK" = (
-/obj/structure/decor_light/wallcandle{
-	pixel_x = 32
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/spline/plain{
-	dir = 8
-	},
-/obj/effect/floor_decal/spline/fancy{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "fZL" = (
 /obj/structure/bed/chair{
@@ -27416,16 +26567,16 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 4
 	},
-/turf/simulated/floor/industrial/greybricks,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "fZN" = (
-/obj/structure/closet/secure_closet/personal/shipbreaker,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /obj/structure/window/reinforced,
+/obj/structure/closet/random_milsupply,
 /turf/simulated/floor/tiled/white/techfloor_grid,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "fZZ" = (
 /obj/random/junk/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -27451,9 +26602,7 @@
 /obj/effect/floor_decal/spline/fancy/corner{
 	dir = 1
 	},
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark/golden,
 /area/liberty/bonfire/vectorrooms)
 "gaC" = (
 /obj/structure/cable/green{
@@ -27601,9 +26750,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/bioreactor)
 "gcp" = (
 /obj/structure/cable/cyan{
@@ -27687,14 +26834,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 4
-	},
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "gcL" = (
 /obj/structure/flora/small/trailrockb5,
@@ -28173,7 +27313,7 @@
 "gii" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild1,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "gik" = (
 /obj/item/organ/internal/kidney,
 /obj/item/organ/internal/kidney/left,
@@ -28195,21 +27335,12 @@
 /obj/structure/barricade,
 /turf/simulated/floor/plating/under,
 /area/liberty/maintenance/undergroundfloor2south)
-"giu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white/golden,
-/area/liberty/bonfire/vectorrooms)
 "gix" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/bioreactor)
 "giT" = (
 /obj/effect/floor_decal/industrial/danger{
@@ -28322,25 +27453,6 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/liberty/engineering/atmos)
-"gkK" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 1
-	},
-/obj/effect/floor_decal/border/carpet/black,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/liberty/bonfire/stronghold)
 "gkO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/rods/random,
@@ -28378,13 +27490,12 @@
 /area/liberty/crew_quarters/hotsprings)
 "glk" = (
 /obj/effect/floor_decal/industrial/hatch,
-/obj/structure/reagent_dispensers/scorch,
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled/dark/golden,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/storage)
 "gll" = (
 /obj/effect/floor_decal/spline/plain,
@@ -28417,15 +27528,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/liberty/rnd/lab)
 "glE" = (
-/obj/machinery/newscaster{
-	pixel_y = 32
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
 	},
-/obj/structure/closet/oathbound,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/steel/golden,
-/area/liberty/bonfire/office)
+/obj/structure/table/rack/shelf,
+/turf/simulated/floor/tiled/dark,
+/area/liberty/maintenance/undergroundfloor1east)
 "glN" = (
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/liberty/rnd/xenobiology)
@@ -28557,18 +27666,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/liberty/pros/shuttle)
-"gnE" = (
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 1
-	},
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 4
-	},
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 5
-	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/liberty/bonfire/forge)
 "gnH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -28803,15 +27900,9 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/floor_decal/spline/fancy{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/spline/plain{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "gqG" = (
 /obj/effect/decal/cleanable/dirt,
@@ -29255,7 +28346,7 @@
 "guU" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/sblucarpet,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "guV" = (
 /obj/effect/floor_decal/rust,
 /obj/effect/decal/cleanable/dirt,
@@ -29500,10 +28591,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/turret_protected/ai_upload)
-"gxv" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/wood/tatami,
-/area/liberty/bonfire/stronghold)
 "gxw" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -29732,16 +28819,11 @@
 	pixel_y = 6
 	},
 /obj/item/device/radio/off{
-	pixel_x = 6;
-	pixel_y = 4
-	},
-/obj/item/device/radio/off{
 	pixel_x = -6;
 	pixel_y = 4
 	},
-/obj/item/device/radio/off,
 /turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "gAw" = (
 /obj/effect/floor_decal/spline/fancy/corner{
 	dir = 4
@@ -29785,7 +28867,7 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 8
 	},
-/turf/simulated/floor/industrial/greybricks,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "gBb" = (
 /obj/effect/floor_decal/industrial/road/straight2,
@@ -30009,13 +29091,13 @@
 /turf/simulated/floor/wood/wild4,
 /area/liberty/maintenance/hideout)
 "gDw" = (
-/obj/structure/closet/secure_closet/personal/shipbreaker,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/structure/closet/random_milsupply,
 /turf/simulated/floor/tiled/white/techfloor_grid,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "gDC" = (
 /obj/random/furniture/pottedplant,
 /turf/simulated/floor/tiled/steel,
@@ -30094,10 +29176,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4
 	},
-/obj/effect/floor_decal/spline/fancy{
-	dir = 8
-	},
-/turf/simulated/floor/industrial/greybricks,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "gEM" = (
 /obj/structure/cable/green{
@@ -30252,13 +29331,11 @@
 /obj/structure/table/rack/shelf,
 /obj/item/stack/material/cardboard/random,
 /obj/random/material,
-/obj/random/material,
-/obj/random/material,
 /obj/random/material/low_chance,
 /obj/random/material/low_chance,
 /obj/random/material/low_chance,
 /turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "gGY" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -30516,8 +29593,8 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood/wild3,
-/area/liberty/pros/foreman)
+/turf/simulated/floor/plating/under,
+/area/liberty/maintenance/undergroundfloor1east)
 "gJp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -30779,11 +29856,7 @@
 /turf/simulated/floor/wood/wild4,
 /area/liberty/dungeon/outside/hunter_cabin)
 "gMd" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/effect/floor_decal/spline/fancy{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -30794,11 +29867,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/border/carpet/black,
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 1
-	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/bioreactor)
 "gMe" = (
 /obj/structure/table/glass,
@@ -30890,14 +29959,7 @@
 /turf/simulated/floor/wood,
 /area/liberty/medical/exam_room)
 "gMI" = (
-/obj/machinery/door/airlock/silver{
-	req_access = list(27);
-	name = "Custodians Commons"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/wood,
+/turf/simulated/wall/r_wall,
 /area/liberty/bonfire/vectorrooms)
 "gMR" = (
 /obj/machinery/portable_atmospherics/hydroponics/soil,
@@ -31108,6 +30170,9 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/maintenance_common{
+	req_access = list(12)
 	},
 /turf/simulated/floor/plating,
 /area/liberty/bonfire/bioreactor)
@@ -31372,12 +30437,6 @@
 	},
 /turf/simulated/floor/tiled/steel/bar_dance,
 /area/liberty/crew_quarters/bar)
-"gRW" = (
-/obj/effect/floor_decal/wood/tatami{
-	dir = 10
-	},
-/turf/simulated/floor/wood/tatami,
-/area/liberty/bonfire/stronghold)
 "gRX" = (
 /obj/structure/closet/crate/secure/bin,
 /obj/item/storage/bag/trash,
@@ -31431,13 +30490,6 @@
 	},
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/liberty/rnd/server)
-"gSB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/spline/fancy,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
-/area/liberty/bonfire/office)
 "gSQ" = (
 /turf/simulated/shuttle/wall/science{
 	icon_state = "4,14"
@@ -31467,19 +30519,6 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/liberty/security/maingate_outside)
-"gSX" = (
-/obj/structure/bed/chair/comfy/brown{
-	dir = 1
-	},
-/obj/effect/floor_decal/border/carpet/red{
-	dir = 8
-	},
-/obj/effect/floor_decal/border/carpet/red,
-/obj/effect/floor_decal/border/carpet/red{
-	dir = 10
-	},
-/turf/simulated/floor/carpet,
-/area/liberty/bonfire/stronghold)
 "gSZ" = (
 /obj/structure/catwalk,
 /obj/structure/railing,
@@ -31515,7 +30554,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "gTx" = (
 /obj/structure/cable/green{
 	d2 = 8;
@@ -31731,10 +30770,8 @@
 /area/liberty/medical/medbay/uppercor)
 "gVR" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/wood/tatami{
-	dir = 1
-	},
-/turf/simulated/floor/wood/tatami,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "gVU" = (
 /obj/structure/cable/green{
@@ -31757,36 +30794,25 @@
 "gWh" = (
 /obj/structure/bed/chair,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/bioreactor)
 "gWr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "East APC";
-	pixel_x = 28
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 8
 	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/wood,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/vectorrooms)
 "gWs" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/wall_mounted/emcloset{
-	pixel_y = 32
-	},
-/obj/effect/floor_decal/industrial/box/white/corners,
-/obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/warningwhite{
-	dir = 1
+/obj/machinery/door/airlock/glass{
+	name = "Kitchen Access";
+	req_access = list(25)
 	},
 /turf/simulated/floor/tiled/steel/bar_flat,
 /area/liberty/crew_quarters/barbackroom)
@@ -31849,10 +30875,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/liberty/rnd/lab)
 "gWZ" = (
-/obj/structure/table/woodentable,
-/obj/item/gunbox/forehead,
-/turf/simulated/floor/tiled/steel/brown_platform,
-/area/liberty/pros/foreman)
+/obj/effect/decal/cleanable/dirt,
+/obj/random/mob/spiders,
+/turf/simulated/floor/plating/under,
+/area/liberty/maintenance/undergroundfloor1east)
 "gXa" = (
 /obj/machinery/light{
 	dir = 4
@@ -32025,19 +31051,13 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 1
-	},
-/obj/effect/floor_decal/border/carpet/black,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "gYF" = (
 /obj/effect/decal/cleanable/dirt,
@@ -32215,17 +31235,10 @@
 /area/liberty/maintenance/undergroundfloor2north)
 "haP" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/spline/fancy{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/obj/effect/floor_decal/spline/plain/corner,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "haR" = (
 /obj/structure/cable/cyan{
@@ -32233,18 +31246,13 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 1
-	},
-/obj/effect/floor_decal/border/carpet/black,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/tiled/dark/golden,
 /area/liberty/bonfire/storage)
 "haV" = (
 /obj/structure/extinguisher_cabinet{
@@ -32639,15 +31647,14 @@
 /turf/simulated/floor/plating/under,
 /area/liberty/maintenance/undergroundfloor2south)
 "hgj" = (
-/obj/machinery/door/airlock/mining{
-	name = "Fontaine Prep";
-	req_access = list(78)
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/maintenance_common{
+	req_access = list(12)
+	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "hgv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -32676,16 +31683,14 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/liberty/medical/genetics)
 "hgD" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/wood/wild3,
-/area/liberty/pros/foreman)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating/under,
+/area/liberty/maintenance/undergroundfloor1east)
 "hgT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -32824,15 +31829,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/substation/cargo)
-"hic" = (
-/obj/machinery/door/window/westright,
-/obj/structure/table/rack,
-/obj/random/booze/low_chance,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
 "hie" = (
 /obj/structure/sign/painting/monkey,
 /turf/simulated/wall/r_wall,
@@ -32983,13 +31979,10 @@
 /turf/simulated/floor/wood,
 /area/liberty/medical/psych)
 "hkb" = (
-/obj/effect/floor_decal/border/carpet/red{
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "hkf" = (
 /obj/structure/railing{
@@ -33021,14 +32014,8 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 4
-	},
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/bcarpet,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "hkp" = (
 /obj/structure/noticeboard/medical,
@@ -33193,24 +32180,8 @@
 /obj/structure/table/bench/wooden,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/spline/fancy,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark/golden,
 /area/liberty/bonfire/vectorrooms)
-"hmd" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "East APC";
-	pixel_x = 28
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/industrial_pristine/greybricks{
-	dir = 1
-	},
-/area/liberty/bonfire/alchemist)
 "hmh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/steel_reinforced,
@@ -33238,7 +32209,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/carpet/sblucarpet,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "hmD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/coatrack,
@@ -33774,10 +32745,9 @@
 /area/liberty/rnd/xenoflora)
 "htn" = (
 /obj/structure/table/steel,
-/obj/item/storage/box/cdeathalarm_kit,
 /obj/item/implanter,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/liberty/pros/prep)
+/turf/simulated/floor/plating/under,
+/area/liberty/maintenance/undergroundfloor1east)
 "htq" = (
 /obj/effect/floor_decal/industrial/danger{
 	dir = 9
@@ -34369,9 +33339,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/spline/fancy/corner,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark/golden,
 /area/liberty/bonfire/vectorrooms)
 "hyX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -34573,26 +33541,18 @@
 /turf/simulated/floor/industrial/blue_slates,
 /area/liberty/maintenance/undergroundfloor3west)
 "hAG" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/floor_decal/spline/fancy{
-	dir = 1
-	},
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/effect/floor_decal/border/carpet/black,
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 1
-	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/bioreactor)
 "hAV" = (
 /obj/structure/bed/chair/office/light{
@@ -34616,7 +33576,7 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "hBk" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -34663,10 +33623,6 @@
 /obj/structure/invislight/outside,
 /turf/simulated/mineral,
 /area/liberty/outside/forest)
-"hBY" = (
-/obj/structure/closet/secure_closet/personal/shipbreaker,
-/turf/simulated/floor/tiled/steel/brown_perforated,
-/area/liberty/pros/prep)
 "hBZ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/cyan{
@@ -34728,14 +33684,11 @@
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/liberty/security/tactical)
 "hCQ" = (
-/obj/effect/floor_decal/spline/fancy,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "hCV" = (
 /turf/simulated/floor/snow,
@@ -34833,21 +33786,14 @@
 /turf/simulated/floor/plating/under,
 /area/liberty/crew_quarters/barbackroom)
 "hEk" = (
-/obj/machinery/multistructure/bonfire_part/unloader,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/bioreactor)
 "hEo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating/under,
 /area/liberty/engineering/engine_room)
-"hEt" = (
-/obj/effect/floor_decal/spline/fancy{
-	dir = 9
-	},
-/obj/structure/decor_light/beacon,
-/turf/simulated/floor/tiled/dark/panels,
-/area/liberty/bonfire/storage)
 "hEx" = (
 /turf/simulated/floor/tiled/dark,
 /area/liberty/quartermaster/hangarsupply)
@@ -34941,7 +33887,7 @@
 	dir = 8;
 	frequency = 1441;
 	name = "Tank Monitor";
-	sensors = list("n2_sensor"="Nitrogen","o2_sensor"="Oxygen","co2_sensor"="Carbon    Dioxide","tox_sensor"="Toxins","n2o_sensor"="Nitrous    Oxide","waste_sensor"="Gas    Mix    Tank")
+	sensors = list("n2_sensor"="Nitrogen","o2_sensor"="Oxygen","co2_sensor"="Carbon        Dioxide","tox_sensor"="Toxins","n2o_sensor"="Nitrous        Oxide","waste_sensor"="Gas        Mix        Tank")
 	},
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/liberty/engineering/atmos/surface)
@@ -35197,7 +34143,7 @@
 "hHQ" = (
 /obj/structure/table/gamblingtable,
 /turf/simulated/floor/carpet/sblucarpet,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "hHX" = (
 /obj/structure/barricade,
 /turf/simulated/floor/rock,
@@ -35273,16 +34219,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/undergroundfloor2east)
-"hIY" = (
-/obj/structure/bed/chair/comfy/brown{
-	dir = 1
-	},
-/obj/effect/floor_decal/border/carpet/red,
-/obj/structure/decor_light/wallcandle{
-	pixel_y = -32
-	},
-/turf/simulated/floor/carpet,
-/area/liberty/bonfire/stronghold)
 "hJa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -35369,8 +34305,16 @@
 /turf/unsimulated/wall/snow,
 /area/liberty/outside/forest)
 "hJR" = (
-/obj/structure/low_wall/custodian,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
+/obj/machinery/door/airlock/maintenance_common{
+	req_access = list(12)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/golden,
 /area/liberty/bonfire/vectorrooms)
 "hJW" = (
 /obj/random/mob/termite_no_despawn,
@@ -35745,9 +34689,7 @@
 /obj/effect/floor_decal/spline/fancy/corner{
 	dir = 4
 	},
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark/golden,
 /area/liberty/bonfire/vectorrooms)
 "hPo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -35831,18 +34773,13 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 1
-	},
-/obj/effect/floor_decal/border/carpet/black,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/tiled/dark/golden,
 /area/liberty/bonfire/storage)
 "hQy" = (
 /obj/structure/grille{
@@ -35976,24 +34913,15 @@
 /turf/simulated/floor/tiled/techmaint_panels,
 /area/liberty/maintenance/undergroundfloor2east)
 "hRx" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/machinery/alarm{
 	pixel_y = 32
 	},
 /obj/structure/disposalpipe/junction/yjunction,
-/obj/effect/floor_decal/spline/fancy{
-	dir = 1
-	},
-/obj/structure/table/bench/wooden,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "hRA" = (
 /obj/effect/decal/cleanable/dirt,
@@ -36046,7 +34974,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "hSh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/landmark/join/start/watchmen,
@@ -36092,34 +35020,14 @@
 /turf/unsimulated/wall/snow,
 /area/liberty/outside/forest)
 "hSS" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/effect/floor_decal/border/carpet/black/corner{
-	dir = 6
-	},
-/obj/effect/floor_decal/border/carpet/black/corner{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/bcarpet,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "hSU" = (
 /obj/structure/table/steel,
@@ -36482,13 +35390,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/liberty/rnd/xenobiology)
 "hXJ" = (
-/obj/effect/window_lwall_spawn/smartspawn/church,
 /obj/structure/invislight,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/blast/regular/open{
 	id = "Colony Lockdown";
 	name = "Colony Lockdown"
 	},
+/obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/liberty/bonfire/vectorrooms)
 "hXN" = (
@@ -36633,9 +35541,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/liberty/maintenance/substation/science)
-"hZB" = (
-/turf/simulated/floor/wood/tatami,
-/area/liberty/bonfire/stronghold)
 "hZW" = (
 /obj/structure/bed/chair/office/light{
 	dir = 8
@@ -36681,20 +35586,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/liberty/security/tactical)
-"iaz" = (
-/obj/structure/bed/chair/wood{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/border/carpet/red{
-	dir = 4
-	},
-/obj/effect/floor_decal/border/carpet/red,
-/obj/effect/floor_decal/border/carpet/red{
-	dir = 6
-	},
-/turf/simulated/floor/carpet,
-/area/liberty/bonfire/vectorrooms)
 "iaA" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/wall/r_wall,
@@ -36723,14 +35614,11 @@
 	name = "Custodians - Workshop";
 	sortType = "Custodians - Workshop"
 	},
-/obj/effect/floor_decal/spline/plain,
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "ibu" = (
 /obj/structure/disposalpipe/segment{
@@ -36751,17 +35639,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/liberty/rnd/research)
-"ibE" = (
-/obj/machinery/door/airlock/silver{
-	req_access = list(27);
-	name = "Custodians Commons"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/liberty/bonfire/vectorrooms)
 "ibH" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -36921,21 +35798,13 @@
 /turf/simulated/floor/rock,
 /area/liberty/maintenance/northcave)
 "idM" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
-/obj/effect/floor_decal/spline/fancy/corner{
-	dir = 1
-	},
-/obj/effect/floor_decal/spline/fancy/corner{
-	dir = 4
-	},
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark/golden,
 /area/liberty/bonfire/vectorrooms)
 "idN" = (
 /obj/effect/floor_decal/industrial/caution{
@@ -37057,7 +35926,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "ifM" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -37260,9 +36129,7 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
 	},
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "iiP" = (
 /obj/structure/boulder,
@@ -38010,11 +36877,13 @@
 /turf/simulated/floor/rock,
 /area/liberty/maintenance/undergroundfloor2west)
 "iqJ" = (
-/obj/machinery/portable_atmospherics/hydroponics,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel/techfloor_grid,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/gray_platform,
 /area/liberty/crew_quarters/hydroponics)
 "iqX" = (
 /obj/structure/cable/yellow{
@@ -38176,17 +37045,10 @@
 /turf/simulated/wall/r_wall,
 /area/liberty/quartermaster/fightclub)
 "isS" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 8
 	},
-/obj/effect/floor_decal/spline/fancy{
-	dir = 4
-	},
-/turf/simulated/floor/industrial/greybricks,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "itc" = (
 /obj/effect/decal/cleanable/dirt,
@@ -38239,9 +37101,7 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 5
 	},
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark/golden,
 /area/liberty/bonfire/vectorrooms)
 "itU" = (
 /turf/simulated/shuttle/floor/mining{
@@ -38551,9 +37411,7 @@
 /obj/effect/floor_decal/spline/fancy/corner{
 	dir = 1
 	},
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "iwD" = (
 /obj/structure/flora/small/snow/rock8,
@@ -38678,8 +37536,10 @@
 /obj/machinery/light_switch{
 	pixel_y = 32
 	},
-/turf/simulated/floor/carpet,
-/area/liberty/pros/foreman)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/gibs,
+/turf/simulated/floor/plating/under,
+/area/liberty/maintenance/undergroundfloor1east)
 "ixG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/padded,
@@ -38795,24 +37655,6 @@
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/liberty/command/panic_room)
-"iyZ" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/landmark/join/start/oathbound,
-/obj/effect/floor_decal/spline/fancy{
-	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 4
-	},
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
-/area/liberty/bonfire/office)
 "izd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -38845,7 +37687,7 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 4
 	},
-/turf/simulated/floor/industrial/greybricks,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "izh" = (
 /obj/effect/decal/cleanable/dirt,
@@ -39052,9 +37894,7 @@
 /obj/effect/floor_decal/spline/fancy/corner{
 	dir = 4
 	},
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "iBv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -39232,7 +38072,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/tiled/dark/golden,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "iDR" = (
 /obj/structure/flora/tree/snow/five,
@@ -39268,16 +38108,6 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/steel/bar_dance,
 /area/liberty/maintenance/sunkenclub)
-"iEn" = (
-/obj/structure/table/rack,
-/obj/effect/floor_decal/spline/fancy{
-	dir = 1
-	},
-/obj/item/vacuum_cleaner,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
-/area/liberty/bonfire/bioreactor)
 "iEo" = (
 /obj/structure/catwalk,
 /obj/random/material_resources/low_chance,
@@ -39344,9 +38174,6 @@
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/liberty/crew_quarters/skyyard)
-"iFk" = (
-/turf/simulated/floor/carpet,
-/area/liberty/bonfire/stronghold)
 "iFo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 1
@@ -39487,8 +38314,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/wood/wild3,
-/area/liberty/pros/foreman)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/liberty/maintenance/undergroundfloor1east)
 "iHl" = (
 /obj/structure/catwalk,
 /obj/random/traps,
@@ -39580,9 +38408,7 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
 	},
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "iIo" = (
 /obj/structure/bed/padded,
@@ -39601,18 +38427,6 @@
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/liberty/crew_quarters/dorm5)
-"iIu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/unary/vent_scrubber,
-/obj/machinery/autolathe/flarelathe,
-/obj/effect/floor_decal/spline/fancy/corner{
-	dir = 4
-	},
-/obj/effect/floor_decal/spline/fancy/corner{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/liberty/bonfire/forge)
 "iIz" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
@@ -39724,7 +38538,6 @@
 /turf/simulated/floor/tiled/steel,
 /area/liberty/quartermaster/office)
 "iJK" = (
-/obj/structure/table/rack,
 /obj/effect/floor_decal/industrial/warningwhite/full,
 /obj/machinery/light{
 	dir = 8
@@ -39732,8 +38545,9 @@
 /obj/machinery/holoposter{
 	pixel_x = -32
 	},
+/obj/structure/table/rack/shelf,
 /turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "iJQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -39802,13 +38616,11 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/liberty/engineering/atmos/storage)
 "iKO" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/wood,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/vectorrooms)
 "iKS" = (
 /obj/effect/decal/cleanable/rubble,
@@ -39819,12 +38631,6 @@
 /obj/machinery/computer/genetics/clone_console,
 /turf/simulated/floor/tiled/dark/danger,
 /area/liberty/medical/genetics)
-"iKY" = (
-/obj/effect/floor_decal/wood/tatami{
-	dir = 5
-	},
-/turf/simulated/floor/wood/tatami,
-/area/liberty/bonfire/stronghold)
 "iLg" = (
 /obj/machinery/camera/network/medbay{
 	dir = 4
@@ -40014,43 +38820,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/liberty/maintenance/undergroundfloor3north)
-"iMY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/wood,
-/area/liberty/bonfire/vectorrooms)
 "iNa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/liberty/security/armoryshop)
-"iNj" = (
-/obj/structure/decor_light/wallcandle{
-	pixel_y = 32
-	},
-/obj/structure/table/woodentable,
-/obj/item/computer_hardware/hard_drive/portable/design/nt/healing,
-/obj/item/computer_hardware/hard_drive/portable/design/nt/forging,
-/obj/item/computer_hardware/hard_drive/portable/design/nt/textiles,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/spline/fancy{
-	dir = 1
-	},
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
-/area/liberty/bonfire/forge)
 "iNk" = (
 /obj/structure/catwalk,
 /obj/structure/ore_box,
@@ -40082,12 +38856,6 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/liberty/security/mess_hall)
-"iNZ" = (
-/obj/structure/decor_light/wallcandle{
-	pixel_y = 32
-	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/liberty/command/prime)
 "iOr" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 1
@@ -40137,16 +38905,6 @@
 /obj/item/storage/box/matches,
 /turf/simulated/floor/wood,
 /area/liberty/maintenance/undergroundfloor2north)
-"iOX" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/spline/fancy,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
-/area/liberty/bonfire/forge)
 "iPc" = (
 /turf/simulated/wall/r_wall,
 /area/liberty/rnd/xenobiology/ameridian)
@@ -40182,7 +38940,7 @@
 	pixel_y = -30
 	},
 /turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "iQq" = (
 /obj/effect/decal/cleanable/ash,
 /obj/effect/decal/cleanable/dirt,
@@ -40288,8 +39046,9 @@
 /area/liberty/maintenance/undergroundfloor2north)
 "iRG" = (
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/wood/wild3,
-/area/liberty/pros/foreman)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/liberty/maintenance/undergroundfloor1east)
 "iRI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -40680,7 +39439,10 @@
 /obj/machinery/portable_atmospherics/hydroponics{
 	pixel_y = 4
 	},
-/turf/simulated/floor/tiled/steel/techfloor_grid,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/gray_perforated,
 /area/liberty/crew_quarters/hydroponics)
 "iWN" = (
 /obj/machinery/door/airlock/multi_tile/glass{
@@ -40880,16 +39642,6 @@
 /obj/structure/table/rack,
 /turf/simulated/floor/tiled/dark,
 /area/liberty/crew_quarters/toilet/public)
-"iYl" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/obj/effect/floor_decal/wood/tatami{
-	dir = 1
-	},
-/turf/simulated/floor/wood/tatami,
-/area/liberty/bonfire/stronghold)
 "iYn" = (
 /obj/random/furniture/pottedplant,
 /obj/machinery/power/apc{
@@ -40926,22 +39678,6 @@
 /obj/structure/railing,
 /turf/simulated/floor/plating/under,
 /area/liberty/bonfire/bioreactor)
-"iYN" = (
-/obj/machinery/door/unpowered/simple/wood/saloon{
-	name = "Church Foyer"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
-/area/liberty/bonfire/vectorrooms)
 "iYR" = (
 /obj/random/mob/roaches/low_chance,
 /turf/simulated/floor/asteroid/dirt/mud,
@@ -41203,6 +39939,10 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/railing{
+	dir = 1;
+	tag = "icon-railing0 (NORTH)"
+	},
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/liberty/hallway/surface/section1)
 "jbr" = (
@@ -41391,8 +40131,8 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/obj/landmark/join/start/oathbound,
-/turf/simulated/floor/wood/tatami,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "jdo" = (
 /obj/structure/flora/snowgrass/vegetation,
@@ -41403,11 +40143,10 @@
 /turf/simulated/floor/industrial/navy_slates,
 /area/liberty/maintenance/saloon)
 "jdr" = (
-/obj/machinery/autolathe,
 /obj/structure/catwalk,
-/obj/machinery/camera/network/fontaine,
+/obj/machinery/craftingstation,
 /turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "jdA" = (
 /obj/structure/flora/tree/snow/snow,
 /obj/structure/flora/grass/both,
@@ -41501,15 +40240,12 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/oldmining)
 "jeJ" = (
-/obj/structure/disposalpipe/segment{
+/obj/structure/toilet,
+/obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/floor_decal/spline/plain,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
-/area/liberty/bonfire/stronghold)
+/turf/simulated/floor/tiled/dark,
+/area/liberty/bonfire/vectorrooms)
 "jeQ" = (
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/liberty/rnd/lab)
@@ -41542,14 +40278,6 @@
 /obj/machinery/vending/citadel,
 /turf/simulated/floor/industrial/navy_large_slates,
 /area/liberty/maintenance/sunkenclub)
-"jfm" = (
-/obj/machinery/disposal,
-/obj/effect/floor_decal/industrial/box/red,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/forge)
 "jfo" = (
 /turf/simulated/wall/r_wall,
 /area/liberty/crew_quarters/toilet)
@@ -41736,17 +40464,11 @@
 /turf/simulated/floor/wood/wild1,
 /area/liberty/maintenance/oldlibrary)
 "jhX" = (
-/obj/structure/railing/grey{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/power/torchbearer,
-/obj/effect/floor_decal/wood/tatami{
-	dir = 8
-	},
-/turf/simulated/floor/wood/tatami,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "jhZ" = (
 /obj/random/boxes,
@@ -41962,17 +40684,6 @@
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/liberty/rnd/xenobiology)
-"jkr" = (
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 8
-	},
-/obj/effect/floor_decal/border/carpet/black,
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/bcarpet,
-/area/liberty/bonfire/forge)
 "jku" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -42349,13 +41060,10 @@
 /area/liberty/quartermaster/disposaldrop)
 "jot" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/decor_light/wallcandle{
-	pixel_x = 32
-	},
 /obj/effect/floor_decal/spline/fancy{
 	dir = 5
 	},
-/turf/simulated/floor/industrial/greybricks,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "jov" = (
 /obj/random/cluster/roaches,
@@ -42517,22 +41225,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/turret_protected/ai)
-"jqZ" = (
-/obj/machinery/multistructure/bonfire_part/platform{
-	make_glasswalls_after_creation = 1
-	},
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/liberty/bonfire/bioreactor)
-"jrg" = (
-/obj/machinery/atmospherics/unary/vent_scrubber,
-/obj/machinery/light_switch{
-	dir = 4;
-	pixel_x = -32
-	},
-/turf/simulated/floor/industrial_pristine/greybricks{
-	dir = 1
-	},
-/area/liberty/bonfire/alchemist)
 "jrl" = (
 /obj/item/modular_computer/console/preset/trade{
 	dir = 1
@@ -42570,17 +41262,16 @@
 /area/liberty/maintenance/undergroundfloor2south)
 "jrJ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/effect/floor_decal/spline/fancy/corner{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/spline/fancy/corner{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/spline/fancy{
 	dir = 1
 	},
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark/golden,
 /area/liberty/bonfire/vectorrooms)
 "jrQ" = (
 /obj/structure/table/standard,
@@ -42622,9 +41313,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/storage)
 "jsi" = (
 /obj/structure/table/rack/shelf,
@@ -42890,7 +41579,7 @@
 /turf/simulated/floor/wood/wild3,
 /area/liberty/crew_quarters/bar)
 "jvb" = (
-/turf/simulated/wall/church_reinforced,
+/turf/simulated/wall/r_wall,
 /area/liberty/bonfire/storage)
 "jvc" = (
 /turf/simulated/floor/tiled/dark/violetcorener,
@@ -43031,15 +41720,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 4
-	},
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 8
-	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "jwP" = (
 /obj/structure/table/steel_reinforced,
@@ -43060,16 +41742,6 @@
 /obj/random/traps,
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/maint_merc)
-"jxp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/liberty/bonfire/vectorrooms)
 "jxz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -43315,11 +41987,6 @@
 /obj/structure/table/bench/padded,
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/undergroundfloor1west)
-"jzX" = (
-/obj/structure/railing/grey,
-/obj/effect/floor_decal/wood/tatami,
-/turf/simulated/floor/wood/tatami,
-/area/liberty/bonfire/stronghold)
 "jAe" = (
 /obj/structure/flora/tree/pine,
 /turf/unsimulated/wall/snow,
@@ -43386,18 +42053,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 1
-	},
-/obj/effect/floor_decal/border/carpet/black,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 5
-	},
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 6
-	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/tiled/dark/golden,
 /area/liberty/bonfire/storage)
 "jAP" = (
 /obj/effect/decal/cleanable/dirt,
@@ -43407,9 +42063,10 @@
 /turf/simulated/floor/industrial/ceramic,
 /area/liberty/maintenance/undergroundfloor1east)
 "jAR" = (
-/obj/structure/bookcase/guncase,
+/obj/structure/table/rack/shelf,
+/obj/structure/window/reinforced,
 /turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "jBc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -43724,7 +42381,6 @@
 "jEy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/standard,
-/obj/item/circuitboard/puncher,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/liberty/engineering/workshop)
 "jED" = (
@@ -43784,31 +42440,6 @@
 /obj/structure/curtain/open/privacy,
 /turf/simulated/floor/tiled/white/cargo,
 /area/liberty/medical/cryo)
-"jFM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/floor_decal/border/carpet/black,
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 4
-	},
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/bcarpet,
-/area/liberty/bonfire/stronghold)
 "jFP" = (
 /obj/structure/table/steel,
 /obj/machinery/door/blast/shutters/glass,
@@ -43926,9 +42557,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/liberty/engineering/engine_room)
-"jGR" = (
-/turf/simulated/floor/wood/wild3,
-/area/liberty/pros/foreman)
 "jGY" = (
 /obj/structure/flora/big/bush3,
 /turf/unsimulated/wall/jungle,
@@ -44257,10 +42885,7 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/substation/bridge)
 "jKQ" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/golden,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/vectorrooms)
 "jKR" = (
 /obj/machinery/power/terminal{
@@ -44307,12 +42932,12 @@
 /turf/simulated/shuttle/floor/mining,
 /area/shuttle/rocinante_shuttle_area)
 "jLi" = (
-/obj/structure/closet/secure_closet/personal/trapper,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
+/obj/structure/closet/random_milsupply,
 /turf/simulated/floor/tiled/white/techfloor_grid,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "jLn" = (
 /obj/effect/floor_decal/spline/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -44353,13 +42978,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/liberty/medical/medbay/uppercor)
-"jLC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/spline/fancy,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
-/area/liberty/bonfire/forge)
 "jLG" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "15,3"
@@ -44465,18 +43083,6 @@
 /obj/structure/table/rack/shelf,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/liberty/maintenance/undergroundfloor3north)
-"jMN" = (
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/obj/effect/floor_decal/wood/tatami{
-	dir = 1
-	},
-/obj/structure/railing/grey{
-	dir = 8
-	},
-/turf/simulated/floor/wood/tatami,
-/area/liberty/bonfire/stronghold)
 "jMQ" = (
 /obj/structure/table/rack/shelf,
 /obj/effect/decal/cleanable/dirt,
@@ -44700,7 +43306,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild1,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "jPT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/wall_mounted/firecloset{
@@ -44714,9 +43320,7 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
 	},
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "jQe" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
@@ -44762,17 +43366,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 1
-	},
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 8
-	},
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "jQW" = (
 /obj/effect/window_lwall_spawn/plasma/reinforced,
@@ -44954,10 +43548,6 @@
 /turf/simulated/floor/wood,
 /area/liberty/command/swo/quarters)
 "jSW" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 2;
@@ -44970,14 +43560,8 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 4
-	},
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/bcarpet,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "jTc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -45245,7 +43829,7 @@
 /obj/effect/floor_decal/industrial/warningwhite/full,
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "jVL" = (
 /obj/structure/shuttle_part/mining{
 	icon_state = "14,23"
@@ -45694,22 +44278,6 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/asteroid/grass,
 /area/liberty/maintenance/undergroundfloor1oldgarden)
-"kai" = (
-/obj/item/stool,
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "West APC";
-	pixel_x = -28
-	},
-/obj/effect/floor_decal/spline/fancy,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
-/area/liberty/bonfire/office)
 "kan" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/machinery/light/small{
@@ -45856,9 +44424,7 @@
 	},
 /obj/effect/floor_decal/industrial/warningwhite,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark/golden,
 /area/liberty/bonfire/bioreactor)
 "kbn" = (
 /obj/machinery/disposal,
@@ -45866,14 +44432,23 @@
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/liberty/maintenance/sunkenclub)
 "kbo" = (
-/obj/machinery/camera/network/fontaine{
-	dir = 1
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/computer/guestpass{
-	pixel_y = -32
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/liberty/hallway/surface/section1)
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/liberty/bonfire/stronghold)
 "kbu" = (
 /obj/machinery/constructable_frame/machine_frame{
 	state = 2
@@ -45902,13 +44477,6 @@
 "kbR" = (
 /turf/simulated/floor/rock,
 /area/liberty/maintenance/undergroundfloor3north)
-"kbT" = (
-/obj/machinery/door/airlock/silver{
-	name = "Toilet"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/white/golden,
-/area/liberty/bonfire/vectorrooms)
 "kbW" = (
 /obj/machinery/light/floor,
 /obj/effect/decal/cleanable/dirt,
@@ -46077,10 +44645,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/undergroundfloor2north)
-"keg" = (
-/obj/structure/table/steel_reinforced,
-/turf/simulated/floor/tiled/steel/brown_perforated,
-/area/liberty/pros/prep)
 "kej" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8
@@ -46347,15 +44911,13 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/undergroundfloor2west)
 "khU" = (
-/obj/machinery/alarm{
-	pixel_y = 32
-	},
-/obj/machinery/camera/network/custodians,
-/obj/structure/sink/basion,
-/turf/simulated/floor/industrial_pristine/greybricks{
+/obj/machinery/atmospherics/unary/vent_scrubber,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
 	dir = 1
 	},
-/area/liberty/bonfire/alchemist)
+/turf/simulated/floor/wood,
+/area/liberty/bonfire/vectorrooms)
 "khX" = (
 /obj/structure/flora/small/snow/rock2,
 /obj/structure/flora/tree/snow/snow,
@@ -46414,15 +44976,8 @@
 /obj/effect/floor_decal/border/carpet/black{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
-"kiq" = (
-/obj/effect/floor_decal/spline/fancy,
-/obj/structure/decor_headless_2,
-/turf/simulated/floor/industrial_pristine/greybricks{
-	dir = 1
-	},
-/area/liberty/bonfire/storage)
 "kit" = (
 /obj/effect/floor_decal/industrial/warningred{
 	dir = 4
@@ -46673,9 +45228,7 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 9
 	},
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "klv" = (
 /obj/structure/reagent_dispensers/watertank,
@@ -46719,11 +45272,6 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/maint_merc)
-"kme" = (
-/obj/structure/table/rack/shelf,
-/obj/random/gun_shotgun,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
 "kmh" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -46983,28 +45531,12 @@
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/liberty/maintenance/arcade)
-"koY" = (
-/obj/effect/floor_decal/spline/fancy/corner{
-	dir = 4
-	},
-/obj/effect/floor_decal/spline/fancy/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks,
-/area/liberty/bonfire/stronghold)
 "kpg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/random/furniture/pottedplant,
 /turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "kpj" = (
 /obj/effect/floor_decal/industrial/warningwhite{
 	dir = 8
@@ -47190,8 +45722,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/barricade,
 /turf/simulated/floor/tiled/steel/gray_perforated,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "kqY" = (
 /obj/machinery/camera/network/gate{
 	dir = 10
@@ -47264,17 +45797,17 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/turf/simulated/floor/plating/under,
+/area/liberty/maintenance/undergroundfloor1east)
 "krJ" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
@@ -47416,8 +45949,8 @@
 /obj/machinery/alarm{
 	pixel_y = 32
 	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/turf/simulated/floor/plating/under,
+/area/liberty/maintenance/undergroundfloor1east)
 "ktZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -47693,9 +46226,6 @@
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
-/obj/structure/bed/chair/office/light{
-	dir = 8
-	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/liberty/crew_quarters/hydroponics)
 "kwY" = (
@@ -47705,8 +46235,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "kxf" = (
 /obj/structure/toilet,
@@ -47811,28 +46340,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/bricks,
 /area/liberty/maintenance/undergroundfloor2north)
-"kyn" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/spline/fancy/corner{
-	dir = 1
-	},
-/obj/effect/floor_decal/spline/fancy/corner,
-/turf/simulated/floor/industrial/greybricks,
-/area/liberty/bonfire/stronghold)
 "kyo" = (
 /obj/machinery/light/floor,
 /obj/effect/decal/cleanable/dirt,
@@ -47857,18 +46364,10 @@
 /turf/simulated/floor/carpet/turcarpet,
 /area/liberty/maintenance/arcade)
 "kyA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/industrial_pristine/greybricks{
-	dir = 1
-	},
-/area/liberty/bonfire/alchemist)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/liberty/bonfire/vectorrooms)
 "kyD" = (
 /obj/machinery/craftingstation,
 /obj/item/stack/material/cardboard/full,
@@ -47993,13 +46492,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/rock/alt,
 /area/liberty/maintenance/undergroundfloor3east)
-"kzW" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 4
-	},
-/obj/landmark/join/start/oathpledge,
-/turf/simulated/floor/carpet/bcarpet,
-/area/liberty/command/prime)
 "kAf" = (
 /obj/structure/flora/tree/snow/four,
 /turf/simulated/floor/snow,
@@ -48242,19 +46734,6 @@
 /obj/structure/curtain/medical,
 /turf/simulated/floor/tiled/white/monofloor,
 /area/liberty/medical/organ_lab)
-"kDL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/border/carpet/red{
-	dir = 8
-	},
-/turf/simulated/floor/carpet,
-/area/liberty/bonfire/stronghold)
 "kDN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -48482,11 +46961,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/effect/floor_decal/spline/plain,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "kGO" = (
 /obj/machinery/light/small{
@@ -48496,15 +46971,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/asteroid,
 /area/liberty/engineering/engine_room)
-"kGU" = (
-/obj/structure/sink{
-	density = 1;
-	desc = "A small fountain of polished stone and has a small pump at the bottom that helps push fresh water.";
-	icon_state = "BaptismFont_Water";
-	name = "Water Fountain"
-	},
-/turf/simulated/floor/tiled/white/golden,
-/area/liberty/bonfire/vectorrooms)
 "kGZ" = (
 /obj/structure/railing,
 /obj/structure/railing{
@@ -48545,20 +47011,8 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/maint_merc)
 "kHV" = (
-/obj/random/furniture/pottedplant,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/wood,
+/obj/structure/table/woodentable,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/vectorrooms)
 "kHX" = (
 /obj/structure/table/reinforced,
@@ -48592,10 +47046,6 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/vasiliy_shuttle_area)
-"kIu" = (
-/obj/machinery/multistructure/bonfire_part/loader,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/liberty/bonfire/bioreactor)
 "kID" = (
 /obj/structure/flora/tree/snow/three,
 /obj/structure/flora/small/snow/rock4,
@@ -48627,21 +47077,6 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/liberty/security/maingate_outside)
-"kIW" = (
-/obj/structure/bed/chair/wood{
-	dir = 1;
-	tag = "icon-wooden_chair (NORTH)"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/border/carpet/red,
-/obj/effect/floor_decal/border/carpet/red{
-	dir = 4
-	},
-/obj/effect/floor_decal/border/carpet/red{
-	dir = 6
-	},
-/turf/simulated/floor/carpet,
-/area/liberty/bonfire/vectorrooms)
 "kJd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -48671,12 +47106,6 @@
 /obj/machinery/air_stopper,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/liberty/hallway/surface/section1)
-"kJs" = (
-/obj/machinery/power/eotp,
-/obj/structure/invislight,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/bcarpet,
-/area/liberty/bonfire/forge)
 "kJG" = (
 /obj/structure/sign/faction/derelict1{
 	desc = "ATTENTION: This teleporter is a highly dangerous piece of equipment, we recommend caution when using it. The device can and will take you to a section of nearby space to salvage equipment, however you will need a void suit and weapons to avoid hostile life forms among the ruins and derelicts. We suggest bringing a team!";
@@ -48854,10 +47283,10 @@
 	},
 /area/shuttle/vasiliy_shuttle_area)
 "kLD" = (
-/turf/simulated/floor/industrial_pristine/greybricks{
-	dir = 1
-	},
-/area/liberty/bonfire/alchemist)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating/under,
+/area/liberty/bonfire/vectorrooms)
 "kLE" = (
 /obj/effect/floor_decal/industrial/danger{
 	dir = 8;
@@ -48941,8 +47370,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/door/airlock/maintenance_common{
+	req_access = list(12)
+	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "kMk" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -49148,16 +47580,15 @@
 	dir = 8;
 	pixel_x = 32
 	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "North APC";
-	pixel_y = 28
-	},
 /obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/tiled/dark/golden,
+/obj/machinery/power/apc/inactive{
+	name = "North APC";
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "kOw" = (
 /obj/machinery/light_switch{
@@ -49227,17 +47658,6 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/liberty/security/sechall)
-"kOY" = (
-/obj/machinery/atmospherics/unary/vent_scrubber,
-/obj/machinery/computer/guestpass{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/structure/decor_light/wallcandle{
-	pixel_y = 32
-	},
-/turf/simulated/floor/wood/wild3,
-/area/liberty/command/prime)
 "kOZ" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 8
@@ -49291,7 +47711,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_scrubber,
 /turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "kPI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_pump{
@@ -49299,17 +47719,6 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/liberty/security/showers)
-"kQf" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 1
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 32
-	},
-/turf/simulated/floor/wood/wild3,
-/area/liberty/command/prime)
 "kQg" = (
 /obj/structure/table/standard,
 /obj/item/storage/box/oracarpetbulk,
@@ -49319,11 +47728,10 @@
 /turf/simulated/floor/tiled/dark/danger,
 /area/liberty/crew_quarters/skyyard)
 "kQw" = (
-/obj/machinery/computer/shuttle_control/multi/rocinante{
-	dir = 4
-	},
-/turf/simulated/floor/carpet,
-/area/liberty/pros/foreman)
+/obj/effect/decal/cleanable/dirt,
+/obj/item/tool/scalpel,
+/turf/simulated/floor/tiled/dark,
+/area/liberty/maintenance/undergroundfloor1east)
 "kQy" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
@@ -49528,14 +47936,11 @@
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/liberty/security/armory)
 "kSm" = (
-/obj/effect/floor_decal/spline/fancy,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "kSD" = (
 /obj/effect/decal/cleanable/dirt,
@@ -49641,11 +48046,16 @@
 /turf/simulated/floor/rock,
 /area/liberty/maintenance/caveagape)
 "kUb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/spline/fancy{
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/industrial/greybricks,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "kUf" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
@@ -49676,16 +48086,12 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/effect/floor_decal/spline/fancy/corner{
-	dir = 8
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/golden,
+/turf/simulated/floor/plating/under,
 /area/liberty/bonfire/storage)
 "kUv" = (
 /obj/structure/window/reinforced,
@@ -49932,8 +48338,7 @@
 /obj/machinery/camera/network/custodians{
 	dir = 1
 	},
-/obj/effect/floor_decal/border/carpet/red,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "kWu" = (
 /obj/random/scrap/dense_weighted/low_chance,
@@ -50057,7 +48462,7 @@
 "kYa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/industrial/loading/white,
-/turf/simulated/floor/tiled/dark/golden,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/bioreactor)
 "kYl" = (
 /obj/effect/decal/cleanable/dirt,
@@ -50608,10 +49013,10 @@
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/liberty/command/bridge)
 "lfX" = (
-/obj/effect/window_lwall_spawn/smartspawn/church,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/liberty/bonfire/stronghold)
 "lgj" = (
@@ -50652,27 +49057,6 @@
 "lgE" = (
 /turf/simulated/wall,
 /area/liberty/crew_quarters/toilet/public)
-"lgI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/floor_decal/border/carpet/red{
-	dir = 4
-	},
-/obj/effect/floor_decal/border/carpet/red{
-	dir = 8
-	},
-/obj/effect/floor_decal/border/carpet/red{
-	dir = 9
-	},
-/obj/effect/floor_decal/border/carpet/red{
-	dir = 5
-	},
-/turf/simulated/floor/carpet,
-/area/liberty/hallway/surface/section1)
 "lgJ" = (
 /obj/structure/boulder,
 /obj/structure/boulder,
@@ -50707,8 +49091,8 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/turf/simulated/floor/plating/under,
+/area/liberty/maintenance/undergroundfloor1east)
 "lgQ" = (
 /obj/structure/table/rack/shelf,
 /obj/item/device/scanner/reagent,
@@ -51009,10 +49393,6 @@
 /obj/item/remains/lizard,
 /turf/simulated/floor/rock/alt,
 /area/liberty/maintenance/northcave)
-"lkc" = (
-/obj/machinery/vending/engineering,
-/turf/simulated/floor/tiled/steel/brown_perforated,
-/area/liberty/pros/prep)
 "lkd" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -51055,13 +49435,8 @@
 /area/liberty/maintenance/undergroundfloor2north)
 "llh" = (
 /obj/machinery/atmospherics/unary/vent_pump,
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "lli" = (
 /obj/structure/bed/chair{
@@ -51284,8 +49659,9 @@
 "lov" = (
 /obj/machinery/atmospherics/unary/vent_scrubber,
 /obj/effect/decal/cleanable/dirt,
+/obj/random/mob/spiders/low_chance,
 /turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "lox" = (
 /obj/structure/table/reinforced,
 /obj/item/genetics/mut_injector,
@@ -51375,8 +49751,8 @@
 /turf/simulated/floor/tiled/steel,
 /area/liberty/quartermaster/miningdock)
 "lpM" = (
-/obj/effect/window_lwall_spawn/smartspawn/church,
 /obj/machinery/door/firedoor,
+/obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/liberty/bonfire/bioreactor)
 "lpU" = (
@@ -51605,7 +49981,7 @@
 /obj/effect/floor_decal/border/carpet/black{
 	dir = 5
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "lse" = (
 /obj/effect/floor_decal/spline/wood{
@@ -51717,8 +50093,8 @@
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/turf/simulated/floor/plating/under,
+/area/liberty/maintenance/undergroundfloor1east)
 "lsY" = (
 /obj/machinery/computer/shuttle_control/multi/rocinante{
 	dir = 1
@@ -52077,8 +50453,9 @@
 	dir = 8;
 	pixel_x = 32
 	},
+/obj/structure/window/reinforced,
 /turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "lxV" = (
 /obj/structure/catwalk,
 /obj/random/junk/low_chance,
@@ -52311,19 +50688,6 @@
 /obj/item/reagent_containers/food/drinks/coffee,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/liberty/security/maingate)
-"lAn" = (
-/obj/item/stock_parts/manipulator,
-/obj/item/circuitboard/vending,
-/obj/item/tool/screwdriver,
-/obj/item/stack/material/steel{
-	amount = 8
-	},
-/obj/item/stock_parts/console_screen,
-/obj/item/stock_parts/matter_bin,
-/obj/item/stack/cable_coil/yellow,
-/obj/structure/table/woodentable,
-/turf/simulated/floor/tiled/steel/golden,
-/area/liberty/bonfire/office)
 "lAt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/catwalk,
@@ -52529,19 +50893,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/liberty/security/interrogation)
-"lDf" = (
-/obj/structure/closet/wall_mounted/emcloset{
-	pixel_y = -32
-	},
-/obj/effect/floor_decal/industrial/warningwhite,
-/obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/golden,
-/area/liberty/bonfire/vectorrooms)
 "lDk" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 8
@@ -52565,7 +50916,7 @@
 /area/liberty/crew_quarters)
 "lDv" = (
 /turf/simulated/floor/wood/wild1,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "lDF" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8
@@ -53082,16 +51433,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 1
-	},
-/obj/effect/floor_decal/border/carpet/black,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "lKj" = (
 /obj/effect/floor_decal/industrial/warning,
@@ -53542,19 +51888,6 @@
 /obj/structure/medical_stand,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/liberty/medical/sleeper)
-"lOD" = (
-/obj/effect/floor_decal/border/carpet/red{
-	dir = 1
-	},
-/obj/effect/floor_decal/border/carpet/red{
-	dir = 8
-	},
-/obj/effect/floor_decal/border/carpet/red{
-	dir = 9
-	},
-/obj/machinery/power/torchbearer,
-/turf/simulated/floor/carpet,
-/area/liberty/bonfire/vectorrooms)
 "lOE" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 1
@@ -53593,10 +51926,8 @@
 /area/liberty/maintenance/undergroundfloor3south)
 "lOH" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/stool,
-/obj/landmark/join/start/shipbreaker,
 /turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "lOP" = (
 /obj/item/pizzabox/hawaiianpizza,
 /obj/structure/table/standard,
@@ -53703,6 +52034,13 @@
 /obj/item/storage/firstaid/ifak,
 /obj/item/storage/firstaid/ifak{
 	pixel_x = 8
+	},
+/obj/item/storage/firstaid/ifak,
+/obj/item/storage/firstaid/ifak{
+	pixel_x = 8
+	},
+/obj/item/storage/firstaid/ifak{
+	pixel_x = -8
 	},
 /turf/simulated/floor/tiled/steel,
 /area/liberty/quartermaster/miningdock)
@@ -53838,13 +52176,6 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/liberty/security/maingate)
-"lRn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/border/carpet/red,
-/turf/simulated/floor/carpet,
-/area/liberty/bonfire/stronghold)
 "lRp" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -53891,12 +52222,9 @@
 /turf/simulated/floor/industrial/blue_slates,
 /area/liberty/maintenance/undergroundfloor2north)
 "lSv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/conveyor_switch/oneway{
-	id = "bonfire1"
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/bioreactor)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/liberty/bonfire/stronghold)
 "lSz" = (
 /obj/structure/table/woodentable,
 /obj/effect/decal/cleanable/dirt,
@@ -54244,14 +52572,10 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/liberty/engineering/engine_room)
 "lWp" = (
-/obj/structure/bed/chair/comfy/brown,
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
-/obj/effect/floor_decal/border/carpet/red{
-	dir = 1
-	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "lWq" = (
 /obj/effect/floor_decal/spline/wood{
@@ -54366,30 +52690,6 @@
 /obj/structure/invislight,
 /turf/simulated/mineral,
 /area/colony)
-"lXv" = (
-/obj/machinery/door/unpowered/simple/wood/saloon{
-	name = "Church Foyer"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
-/area/liberty/bonfire/vectorrooms)
 "lXx" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/navy_large_slates,
@@ -54426,13 +52726,17 @@
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/liberty/maintenance/sunkenclub)
 "lXR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/liberty/bonfire/vectorrooms)
 "lXV" = (
@@ -54457,14 +52761,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 4
-	},
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/bcarpet,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "lYh" = (
 /obj/effect/decal/cleanable/dirt,
@@ -54875,16 +53173,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 1
-	},
-/obj/effect/floor_decal/border/carpet/black,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "mdT" = (
 /obj/machinery/atm{
@@ -55099,8 +53392,7 @@
 /turf/simulated/floor/asteroid/grass,
 /area/liberty/maintenance/substation/sec)
 "mfH" = (
-/obj/structure/flora/small/grassb5,
-/turf/simulated/floor/asteroid/grass,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "mgd" = (
 /obj/effect/decal/cleanable/dirt,
@@ -55284,15 +53576,6 @@
 /obj/structure/table/marble,
 /turf/simulated/floor/wood/wild3,
 /area/liberty/crew_quarters/bar)
-"miP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/wood/tatami{
-	dir = 8
-	},
-/turf/simulated/floor/wood/tatami,
-/area/liberty/bonfire/stronghold)
 "miU" = (
 /obj/effect/overlay/water,
 /obj/effect/overlay/water/top,
@@ -55377,8 +53660,10 @@
 	},
 /area/shuttle/vasiliy_shuttle_area)
 "mkt" = (
-/turf/simulated/wall/r_wall,
-/area/liberty/pros/prep)
+/obj/effect/floor_decal/industrial/warningwhite/full,
+/obj/structure/table/rack,
+/turf/simulated/floor/tiled/dark,
+/area/liberty/maintenance/undergroundfloor1east)
 "mkG" = (
 /obj/structure/multiz/stairs/active{
 	dir = 8
@@ -55513,24 +53798,9 @@
 /turf/simulated/wall/r_wall,
 /area/liberty/medical/organ_lab)
 "mnp" = (
-/obj/machinery/door/bonfire{
-	name = "Custodian Barracks"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/liberty/bonfire/office)
+/turf/simulated/wall/r_wall,
+/area/liberty/bonfire/stronghold)
 "mnq" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -55570,21 +53840,18 @@
 /turf/simulated/mineral/planet,
 /area/liberty/maintenance/undergroundfloor1oldgarden)
 "mod" = (
-/obj/structure/decor_light/wallcandle{
-	pixel_y = -32
-	},
-/obj/machinery/portable_atmospherics/hydroponics/soil,
-/obj/effect/floor_decal/spline/grass_edge{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/obj/item/spice_plant/yerbamate,
-/obj/item/spice_plant/rosemary,
-/obj/item/spice_plant/ginger_root,
-/obj/item/spice_plant/coriander,
-/obj/item/spice_plant/clove,
-/obj/item/spice_plant/marigold,
-/turf/simulated/floor/asteroid/dirt/flood/plough,
-/area/liberty/bonfire/alchemist)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating/under,
+/area/liberty/bonfire/vectorrooms)
 "moh" = (
 /obj/effect/decal/cleanable/vomit,
 /obj/effect/decal/cleanable/dirt,
@@ -55811,22 +54078,6 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai_upload)
-"mrp" = (
-/obj/structure/bookcase,
-/obj/item/book/manual/barman_recipes,
-/obj/item/book/manual/chef_recipes,
-/obj/item/book/manual/engineering_construction,
-/obj/item/book/manual/engineering_guide,
-/obj/item/book/manual/engineering_hacking,
-/obj/item/book/manual/medical_diagnostics_manual,
-/obj/item/book/manual/supermatter_engine,
-/obj/item/book/manual/security_space_law,
-/obj/item/book/manual/anomaly_testing,
-/obj/effect/floor_decal/border/carpet/red{
-	dir = 1
-	},
-/turf/simulated/floor/carpet,
-/area/liberty/bonfire/stronghold)
 "mrz" = (
 /obj/structure/table/standard,
 /obj/random/lowkeyrandom/low_chance,
@@ -55841,8 +54092,7 @@
 /turf/simulated/wall/r_wall,
 /area/liberty/crew_quarters/sleep/cryo2)
 "mrD" = (
-/obj/structure/decor_inloved_2,
-/turf/simulated/floor/tiled/dark/panels,
+/turf/simulated/floor/tiled/dark/golden,
 /area/liberty/bonfire/storage)
 "mrE" = (
 /obj/structure/disposalpipe/segment,
@@ -55879,11 +54129,6 @@
 /obj/structure/invislight,
 /turf/simulated/floor/asteroid/grass,
 /area/liberty/maintenance/undergroundfloor1oldgarden)
-"msb" = (
-/obj/structure/table/rack/shelf,
-/obj/random/gun_shotgun/low_chance,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
 "msj" = (
 /obj/structure/bed/chair/office/dark,
 /obj/landmark/join/start/engineer,
@@ -55978,7 +54223,7 @@
 	pixel_x = -32
 	},
 /turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "mtm" = (
 /obj/structure/disposaloutlet{
 	dir = 4
@@ -56034,6 +54279,7 @@
 /obj/machinery/door/firedoor/multi_tile{
 	dir = 2
 	},
+/obj/structure/railing,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/liberty/hallway/surface/section1)
 "mtF" = (
@@ -56115,20 +54361,6 @@
 /obj/structure/flora/grass/both,
 /turf/simulated/floor/snow,
 /area/liberty/outside/pond)
-"muI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 32
-	},
-/obj/effect/floor_decal/spline/fancy,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
-/area/liberty/bonfire/office)
 "muU" = (
 /obj/structure/reagent_dispensers/watertank/huge,
 /obj/machinery/alarm{
@@ -56156,10 +54388,6 @@
 /obj/random/lowkeyrandom,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/liberty/quartermaster/hangarsupply)
-"mvL" = (
-/obj/structure/sign/warning/caution/small,
-/turf/simulated/wall/r_wall,
-/area/liberty/pros/prep)
 "mvU" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -56543,10 +54771,6 @@
 /obj/random/traps/low_chance,
 /turf/simulated/floor/wood/wild4,
 /area/liberty/maintenance/hideout)
-"mAo" = (
-/obj/structure/multiz/stairs/enter/bottom,
-/turf/simulated/floor/wood/tatami,
-/area/liberty/bonfire/stronghold)
 "mAt" = (
 /obj/structure/table/rack,
 /obj/item/device/techno_tribalism,
@@ -56606,7 +54830,10 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/liberty/hallway/surface/section1)
 "mBk" = (
-/turf/simulated/wall/church_reinforced,
+/obj/machinery/door/airlock/maintenance_common{
+	req_access = list(12)
+	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/vectorrooms)
 "mBu" = (
 /obj/effect/decal/cleanable/blood{
@@ -56643,19 +54870,10 @@
 /turf/simulated/floor/wood/wild1,
 /area/liberty/crew_quarters/dorm1)
 "mCg" = (
-/obj/structure/bed/chair/wood{
-	dir = 1;
-	tag = "icon-wooden_chair (NORTH)"
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/border/carpet/red,
-/obj/effect/floor_decal/border/carpet/red{
-	dir = 8
-	},
-/obj/effect/floor_decal/border/carpet/red{
-	dir = 10
-	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/vectorrooms)
 "mCm" = (
 /obj/machinery/light/small{
@@ -56766,16 +54984,10 @@
 /turf/simulated/floor/reinforced/oxygen,
 /area/liberty/engineering/atmos)
 "mEA" = (
-/obj/structure/decor_headless_1,
-/obj/structure/decor_light/wallcandle{
-	pixel_y = -32
-	},
 /obj/effect/floor_decal/spline/fancy{
 	dir = 6
 	},
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark/golden,
 /area/liberty/bonfire/vectorrooms)
 "mEB" = (
 /obj/structure/table/rack,
@@ -56813,7 +55025,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "mFb" = (
 /obj/structure/multiz/stairs/active/bottom{
 	dir = 4
@@ -57600,19 +55812,6 @@
 	icon_state = "4,6"
 	},
 /area/shuttle/vasiliy_shuttle_area)
-"mNJ" = (
-/obj/structure/railing/grey{
-	dir = 4
-	},
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/obj/structure/decor_light/pyre,
-/obj/effect/floor_decal/wood/tatami{
-	dir = 5
-	},
-/turf/simulated/floor/wood/tatami,
-/area/liberty/bonfire/stronghold)
 "mNL" = (
 /obj/machinery/light,
 /turf/simulated/floor/snow,
@@ -57682,7 +55881,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks,
+/turf/simulated/floor/tiled/dark/golden,
 /area/liberty/bonfire/bioreactor)
 "mOW" = (
 /turf/simulated/wall/rust_reinforced,
@@ -57693,8 +55892,9 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/wood/wild3,
-/area/liberty/pros/foreman)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/liberty/maintenance/undergroundfloor1east)
 "mPa" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/techfloor,
@@ -57726,13 +55926,12 @@
 /area/liberty/rnd/xenoflora)
 "mPm" = (
 /obj/effect/floor_decal/industrial/hatch,
-/obj/structure/reagent_dispensers/scorch,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark/golden,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/storage)
 "mPt" = (
 /turf/simulated/wall/r_wall,
@@ -57856,13 +56055,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/rocinante_shuttle_area)
-"mRj" = (
-/obj/structure/bed/chair/wood,
-/obj/effect/floor_decal/border/carpet/red{
-	dir = 1
-	},
-/turf/simulated/floor/carpet,
-/area/liberty/bonfire/vectorrooms)
 "mRu" = (
 /obj/machinery/door/unpowered/simple/wood/saloon{
 	name = "Church Foyer"
@@ -57872,9 +56064,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/industrial_pristine/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark/golden,
 /area/liberty/bonfire/stronghold)
 "mRv" = (
 /obj/effect/decal/cleanable/dirt/snow,
@@ -57904,8 +56094,11 @@
 /turf/simulated/floor/wood/wild1,
 /area/liberty/crew_quarters/dorm1)
 "mRT" = (
-/obj/structure/table/woodentable,
-/turf/simulated/floor/carpet,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/vectorrooms)
 "mRU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -57958,7 +56151,7 @@
 "mSu" = (
 /obj/machinery/space_heater,
 /turf/simulated/floor/wood/wild1,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "mSy" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -58139,15 +56332,15 @@
 /turf/simulated/floor/rock,
 /area/liberty/maintenance/caveagape)
 "mUI" = (
-/obj/structure/closet/secure_closet/personal/trapper,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/structure/closet/random_milsupply,
 /turf/simulated/floor/tiled/white/techfloor_grid,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "mUJ" = (
 /obj/machinery/light_switch{
 	dir = 4;
@@ -58164,17 +56357,8 @@
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/liberty/rnd/server)
 "mUK" = (
-/obj/structure/bed/chair/comfy/brown,
-/obj/effect/floor_decal/border/carpet/red{
-	dir = 8
-	},
-/obj/effect/floor_decal/border/carpet/red{
-	dir = 1
-	},
-/obj/effect/floor_decal/border/carpet/red{
-	dir = 9
-	},
-/turf/simulated/floor/carpet,
+/obj/machinery/space_heater,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "mUL" = (
 /obj/structure/curtain/open/bed,
@@ -58234,7 +56418,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "mVx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bookcase{
@@ -58260,10 +56444,8 @@
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/liberty/hallway/surface/section1)
 "mVB" = (
-/obj/effect/floor_decal/wood/tatami{
-	dir = 8
-	},
-/turf/simulated/floor/wood/tatami,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "mVJ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -58316,7 +56498,7 @@
 /obj/item/stool,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/sblucarpet,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "mWi" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /obj/effect/decal/cleanable/dirt,
@@ -58332,9 +56514,6 @@
 "mWo" = (
 /turf/simulated/wall/r_wall,
 /area/liberty/crew_quarters/skyyard)
-"mWx" = (
-/turf/simulated/floor/carpet/bcarpet,
-/area/liberty/command/prime)
 "mWG" = (
 /obj/structure/boulder,
 /obj/effect/decal/cleanable/dirt,
@@ -58513,13 +56692,10 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild1,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "mYT" = (
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/liberty/command/gmaster)
-"mZb" = (
-/turf/simulated/wall/church_reinforced,
-/area/liberty/bonfire/office)
 "mZd" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/blucarpet,
@@ -58598,14 +56774,11 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/liberty/crew_quarters/dorm2)
 "nag" = (
-/obj/machinery/door/airlock/silver{
-	req_access = list(27);
-	name = "Custodians Commons"
-	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
+/obj/machinery/door/airlock/maintenance_common{
+	req_access = list(12)
 	},
+/turf/simulated/floor/tiled/dark/golden,
 /area/liberty/bonfire/vectorrooms)
 "nah" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -58860,13 +57033,8 @@
 /turf/simulated/floor/plating/under,
 /area/liberty/maintenance/undergroundfloor2west)
 "ndy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/wood,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/vectorrooms)
 "ndA" = (
 /obj/machinery/disposal,
@@ -58922,6 +57090,9 @@
 /area/liberty/maintenance/undergroundfloor3south)
 "ndW" = (
 /obj/machinery/atmospherics/unary/vent_scrubber,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/liberty/crew_quarters/hydroponics)
 "neb" = (
@@ -58932,10 +57103,10 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/undergroundfloor3south)
 "nef" = (
-/obj/structure/closet/wardrobe/misc/pjs,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/effect/decal/cleanable/dirt,
+/mob/living/carbon/superior_animal/giant_spider/nurse/cave_spider,
+/obj/item/clothing/under/costume/kinky/sexy_mime,
+/obj/item/clothing/mask/costume/kinky/sexy_mime,
 /turf/simulated/floor/wood,
 /area/liberty/bonfire/vectorrooms)
 "neg" = (
@@ -59515,10 +57686,6 @@
 	},
 /turf/simulated/floor/tiled/steel/bar_dance,
 /area/liberty/crew_quarters/bar)
-"nkE" = (
-/obj/structure/decor_edvard_statue,
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/stronghold)
 "nkH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/snow,
@@ -59746,8 +57913,7 @@
 /turf/simulated/floor/tiled/dark/greencorner,
 /area/liberty/medical/genetics)
 "nnh" = (
-/obj/structure/decor_inloved_1,
-/turf/simulated/floor/tiled/dark/panels,
+/turf/simulated/floor/plating/under,
 /area/liberty/bonfire/storage)
 "nnn" = (
 /obj/effect/decal/cleanable/generic,
@@ -59796,15 +57962,8 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/liberty/storage/primary)
 "nnD" = (
-/obj/effect/floor_decal/spline/fancy{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/spline/plain{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "nnS" = (
 /obj/random/closet_tech,
@@ -60178,7 +58337,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/wood/wild1,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "nrO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/cigbutt,
@@ -60254,24 +58413,6 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/liberty/engineering/atmos)
-"nsT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "North APC";
-	pixel_y = 28
-	},
-/obj/effect/floor_decal/spline/fancy{
-	dir = 1
-	},
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
-/area/liberty/bonfire/forge)
 "nsV" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -60674,23 +58815,8 @@
 /obj/effect/floor_decal/spline/fancy/corner{
 	dir = 1
 	},
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
-"nxo" = (
-/obj/structure/bed/chair/wood,
-/obj/effect/floor_decal/border/carpet/red{
-	dir = 1
-	},
-/obj/effect/floor_decal/border/carpet/red{
-	dir = 8
-	},
-/obj/effect/floor_decal/border/carpet/red{
-	dir = 9
-	},
-/turf/simulated/floor/carpet,
-/area/liberty/bonfire/vectorrooms)
 "nxq" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -60720,28 +58846,13 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/storage)
 "nxs" = (
 /obj/structure/table/woodentable,
 /obj/item/reagent_containers/food/drinks/drinkingglass,
 /turf/simulated/floor/wood/wild3,
 /area/liberty/crew_quarters)
-"nxy" = (
-/obj/effect/floor_decal/border/carpet/red{
-	dir = 1
-	},
-/obj/effect/floor_decal/border/carpet/red{
-	dir = 4
-	},
-/obj/effect/floor_decal/border/carpet/red{
-	dir = 5
-	},
-/obj/machinery/power/torchbearer,
-/turf/simulated/floor/carpet,
-/area/liberty/bonfire/vectorrooms)
 "nxD" = (
 /obj/structure/sign/department/ass,
 /turf/simulated/wall,
@@ -60944,9 +59055,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark/golden,
 /area/liberty/bonfire/vectorrooms)
 "nAc" = (
 /obj/structure/sign/departmentold/mining,
@@ -60990,21 +59099,6 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/liberty/command/tcommsat/computer)
-"nAI" = (
-/obj/structure/bed/chair/wood{
-	dir = 4;
-	tag = "icon-wooden_chair (EAST)"
-	},
-/obj/effect/floor_decal/border/carpet/red{
-	dir = 8
-	},
-/obj/effect/floor_decal/border/carpet/red,
-/obj/effect/floor_decal/border/carpet/red{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet,
-/area/liberty/bonfire/vectorrooms)
 "nAJ" = (
 /obj/structure/bed/chair/shuttle{
 	dir = 8
@@ -61022,7 +59116,7 @@
 "nBc" = (
 /obj/effect/floor_decal/industrial/loading/white,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/golden,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/bioreactor)
 "nBe" = (
 /obj/effect/decal/cleanable/dirt,
@@ -61320,10 +59414,6 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/mineral/planet,
 /area/liberty/maintenance/northcave)
-"nFc" = (
-/obj/structure/closet/enkindled,
-/turf/simulated/floor/tiled/steel/golden,
-/area/liberty/bonfire/office)
 "nFe" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 8
@@ -61420,19 +59510,8 @@
 /area/liberty/hallway/surface/section1)
 "nGq" = (
 /obj/effect/floor_decal/industrial/hatch,
-/obj/structure/reagent_dispensers/scorch/large,
-/turf/simulated/floor/tiled/dark/golden,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/storage)
-"nGr" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/spline/fancy{
-	dir = 10
-	},
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
-/area/liberty/bonfire/forge)
 "nGu" = (
 /obj/machinery/power/sensor{
 	long_range = 1;
@@ -61497,7 +59576,7 @@
 	pixel_x = 16
 	},
 /turf/simulated/floor/carpet/sblucarpet,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "nGE" = (
 /obj/random/mob/termite_no_despawn,
 /turf/simulated/floor/rock/alt,
@@ -61526,7 +59605,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "nHf" = (
 /obj/machinery/computer/borgupload{
 	dir = 4
@@ -61781,11 +59860,9 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/liberty/crew_quarters/bar)
 "nJD" = (
-/obj/structure/damocles_pedestal{
-	density = 0
-	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/liberty/command/prime)
+/obj/structure/bed/chair/sofa/black,
+/turf/simulated/floor/tiled/dark,
+/area/liberty/bonfire/vectorrooms)
 "nJK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -61994,26 +60071,14 @@
 "nME" = (
 /obj/structure/table/woodentable,
 /obj/effect/floor_decal/spline/fancy,
-/obj/structure/decor_light/wallcandle{
-	pixel_y = -32
-	},
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/bioreactor)
 "nMJ" = (
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 1
-	},
-/obj/effect/floor_decal/border/carpet/black{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/bcarpet,
-/area/liberty/bonfire/stronghold)
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/liberty/crew_quarters/hydroponics)
 "nMM" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
@@ -62074,9 +60139,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/hologram/holopad,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark/golden,
 /area/liberty/bonfire/vectorrooms)
 "nNO" = (
 /turf/simulated/shuttle/wall/science{
@@ -62424,21 +60487,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 1
 	},
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 8
-	},
-/obj/effect/floor_decal/border/carpet/black,
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 4
-	},
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 6
-	},
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/tiled/dark/golden,
 /area/liberty/bonfire/storage)
 "nQy" = (
 /mob/living/simple_animal/hostile/hivebot/range,
@@ -62708,22 +60757,18 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/liberty/security/sechall)
 "nTx" = (
-/obj/machinery/camera/network/custodians,
 /obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "North APC";
-	pixel_y = 28
-	},
 /obj/effect/floor_decal/spline/fancy{
 	dir = 4
 	},
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
+/obj/machinery/power/apc/inactive{
+	name = "North APC";
+	pixel_y = 28
 	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/storage)
 "nTy" = (
 /obj/structure/disposalpipe/segment{
@@ -62894,10 +60939,6 @@
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/liberty/engineering/engine_waste)
 "nVD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/spline/fancy{
-	dir = 1
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -62909,11 +60950,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/border/carpet/black,
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 1
-	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/bioreactor)
 "nVE" = (
 /obj/machinery/atmospherics/pipe/tank/air,
@@ -62990,14 +61027,11 @@
 /turf/simulated/floor/tiled/white,
 /area/liberty/medical/medbay/uppercor)
 "nWX" = (
-/obj/effect/floor_decal/spline/fancy,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "nXe" = (
 /obj/structure/disposalpipe/segment{
@@ -63122,14 +61156,6 @@
 /obj/random/scrap/dense_weighted,
 /turf/simulated/floor/rock,
 /area/liberty/maintenance/cavenightmare)
-"nZj" = (
-/obj/structure/cable/green,
-/obj/machinery/power/apc{
-	name = "South APC";
-	pixel_y = -28
-	},
-/turf/simulated/floor/wood/wild3,
-/area/liberty/command/prime)
 "nZq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/cluster/roaches,
@@ -63195,14 +61221,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 4
-	},
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "nZI" = (
 /obj/effect/window_lwall_spawn/smartspawn/church,
@@ -63430,9 +61449,9 @@
 /turf/simulated/floor/industrial/white_large_slates,
 /area/liberty/maintenance/undergroundfloor1west)
 "ocL" = (
-/obj/effect/window_lwall_spawn/smartspawn/church,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
+/obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/liberty/bonfire/bioreactor)
 "ocM" = (
@@ -63482,10 +61501,6 @@
 	},
 /turf/simulated/floor/snow,
 /area/liberty/hallway/surface/section1)
-"ody" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/bioreactor)
 "odC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/wall_mounted/firecloset{
@@ -63746,7 +61761,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/carpet/sblucarpet,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "ogw" = (
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/rock,
@@ -64221,18 +62236,18 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/network/custodians{
-	dir = 4
-	},
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/spline/fancy{
 	dir = 8
 	},
-/turf/simulated/floor/industrial/greybricks,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "olM" = (
-/turf/simulated/wall/church_reinforced,
-/area/liberty/bonfire/alchemist)
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/liberty/bonfire/vectorrooms)
 "olR" = (
 /obj/structure/table/rack/shelf,
 /obj/random/pack/cloth/low_chance,
@@ -64608,13 +62623,14 @@
 	},
 /area/liberty/maintenance/undergroundfloor2north)
 "opO" = (
-/obj/machinery/power/apc{
+/obj/structure/cable/green,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc/inactive{
 	name = "South APC";
 	pixel_y = -28
 	},
-/obj/structure/cable/green,
-/turf/simulated/floor/wood/wild3,
-/area/liberty/pros/foreman)
+/turf/simulated/floor/plating/under,
+/area/liberty/maintenance/undergroundfloor1east)
 "opU" = (
 /obj/structure/table/steel,
 /obj/item/reagent_containers/food/drinks/dry_ramen,
@@ -64787,9 +62803,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild3,
 /area/liberty/crew_quarters)
-"orL" = (
-/turf/simulated/wall,
-/area/liberty/pros/prep)
 "orP" = (
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/rock,
@@ -64811,19 +62824,6 @@
 /obj/random/closet_maintloot/low_chance,
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/undergroundfloor1north)
-"osi" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/industrial_pristine/greybricks{
-	dir = 1
-	},
-/area/liberty/bonfire/alchemist)
 "osj" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/circuitboard/puncher,
@@ -64898,11 +62898,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/liberty/security/prison)
-"osL" = (
-/obj/structure/table/woodentable,
-/obj/item/toy/plushie/fox/orange,
-/turf/simulated/floor/wood,
-/area/liberty/bonfire/vectorrooms)
 "osM" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
@@ -65357,10 +63352,8 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/undergroundfloor3west)
 "oxv" = (
-/obj/item/stool,
-/obj/landmark/join/start/trapper,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/turf/simulated/floor/plating/under,
+/area/liberty/maintenance/undergroundfloor1east)
 "oxB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/green{
@@ -65530,13 +63523,12 @@
 /area/liberty/security/maingate_outside)
 "ozK" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/mining{
-	name = "Fontaine Prep";
-	req_access = list(78)
-	},
 /obj/machinery/air_stopper,
+/obj/machinery/door/airlock/maintenance_common{
+	req_access = list(12)
+	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "ozL" = (
 /obj/machinery/door/airlock/maintenance_rnd{
 	req_access = list(5)
@@ -65926,16 +63918,6 @@
 /obj/item/modular_computer/console/preset/trade,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/liberty/command/merchant)
-"oDY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/wood,
-/area/liberty/bonfire/vectorrooms)
 "oDZ" = (
 /obj/item/modular_computer/console/preset/security/records{
 	dir = 1
@@ -66891,7 +64873,6 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/undergroundfloor2south)
 "oNU" = (
-/obj/random/mecha/low_chance,
 /obj/machinery/mech_recharger,
 /obj/machinery/light_switch{
 	pixel_y = 27
@@ -66902,15 +64883,6 @@
 /obj/item/modular_computer/console/preset/security/records,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/liberty/security/main)
-"oOl" = (
-/obj/structure/railing/grey{
-	dir = 4
-	},
-/obj/effect/floor_decal/wood/tatami{
-	dir = 4
-	},
-/turf/simulated/floor/wood/tatami,
-/area/liberty/bonfire/stronghold)
 "oOn" = (
 /obj/random/oddity_guns,
 /turf/simulated/floor/rock,
@@ -67046,9 +65018,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/industrial_pristine/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark/golden,
 /area/liberty/bonfire/stronghold)
 "oPY" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -67223,14 +65193,6 @@
 /obj/random/lowkeyrandom/low_chance,
 /turf/simulated/floor/industrial/ceramic,
 /area/liberty/maintenance/undergroundfloor3east)
-"oRX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/spline/fancy,
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
-/area/liberty/bonfire/forge)
 "oSf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/shuttle/floor/science{
@@ -67356,16 +65318,6 @@
 	},
 /turf/simulated/floor/tiled/white/techfloor,
 /area/liberty/quartermaster/disposaldrop)
-"oTj" = (
-/obj/machinery/power/torchbearer{
-	pixel_y = 6
-	},
-/obj/machinery/camera/network/custodians{
-	dir = 8
-	},
-/obj/effect/floor_decal/spline/fancy/three_quarters,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/liberty/bonfire/stronghold)
 "oTn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/spline/fancy,
@@ -67375,9 +65327,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "oTs" = (
 /obj/structure/table/woodentable,
@@ -67434,20 +65384,6 @@
 /obj/structure/curtain/black,
 /turf/simulated/floor/plating,
 /area/liberty/rnd/xenobiology)
-"oUu" = (
-/obj/structure/mirror{
-	pixel_y = -28
-	},
-/obj/structure/sink{
-	pixel_y = -22
-	},
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white/golden,
-/area/liberty/bonfire/vectorrooms)
 "oUC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -67644,7 +65580,7 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 8
 	},
-/turf/simulated/floor/industrial/greybricks,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "oWM" = (
 /obj/effect/decal/cleanable/dirt,
@@ -68122,19 +66058,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 4
-	},
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 8
-	},
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 9
-	},
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 5
-	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "pcw" = (
 /obj/structure/bed/chair/sofa/black/right{
@@ -68259,12 +66183,8 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/effect/floor_decal/spline/fancy{
-	dir = 5
-	},
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "pdG" = (
 /obj/structure/boulder,
@@ -68429,13 +66349,7 @@
 	dir = 8;
 	pixel_x = 26
 	},
-/obj/effect/floor_decal/spline/fancy/cee{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/storage)
 "pfx" = (
 /obj/structure/bed/chair{
@@ -68502,7 +66416,6 @@
 /turf/simulated/floor/tiled/steel,
 /area/liberty/command/courtroom)
 "pgl" = (
-/obj/effect/floor_decal/spline/fancy,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -68511,7 +66424,6 @@
 /obj/machinery/light/floor{
 	pixel_y = 5
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/golden,
 /area/liberty/bonfire/storage)
 "pgv" = (
@@ -68588,18 +66500,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/quartermaster/fightclub)
-"phg" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/table/rack,
-/obj/item/stack/material/steel/full,
-/obj/item/stack/material/glass/full,
-/obj/item/stack/material/plastic/full,
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/forge)
 "phm" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /obj/machinery/door/blast/regular{
@@ -69098,21 +66998,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/liberty/hallway/surface/section1)
-"pnY" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/turf/simulated/floor/wood,
-/area/liberty/bonfire/vectorrooms)
 "poa" = (
 /obj/machinery/pipedispenser,
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -69311,12 +67196,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/liberty/storage/primary)
-"pqg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/wood,
-/area/liberty/bonfire/vectorrooms)
 "pqj" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -69376,8 +67255,10 @@
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/liberty/hallway/surface/section1)
 "prk" = (
-/turf/simulated/floor/carpet,
-/area/liberty/pros/foreman)
+/obj/effect/decal/cleanable/dirt,
+/obj/item/device/defib_kit,
+/turf/simulated/floor/tiled/dark,
+/area/liberty/maintenance/undergroundfloor1east)
 "prr" = (
 /turf/simulated/floor/fixed/hydrotile,
 /area/turret_protected/ai)
@@ -69436,12 +67317,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/liberty/maintenance/undergroundfloor2south)
-"prG" = (
-/obj/effect/floor_decal/wood/tatami{
-	dir = 1
-	},
-/turf/simulated/floor/wood/tatami,
-/area/liberty/bonfire/stronghold)
 "prT" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /obj/structure/railing{
@@ -69538,16 +67413,10 @@
 /turf/simulated/floor/industrial/blue_slates,
 /area/liberty/maintenance/undergroundfloor3west)
 "psQ" = (
-/obj/structure/sign/departmentold/restroom{
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/vectorrooms)
 "psW" = (
 /obj/machinery/washing_machine,
@@ -69560,14 +67429,8 @@
 /area/liberty/crew_quarters/toilet)
 "ptb" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/spline/fancy{
-	dir = 4
-	},
-/obj/machinery/camera/network/custodians{
-	dir = 8
-	},
-/turf/simulated/floor/industrial/greybricks,
-/area/liberty/bonfire/stronghold)
+/turf/simulated/floor/plating/under,
+/area/liberty/bonfire/storage)
 "ptk" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
@@ -69660,7 +67523,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood/wild3,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "pun" = (
 /obj/effect/decal/cleanable/dirt,
@@ -69788,20 +67651,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/substation/cargo)
-"pvP" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/spline/fancy{
-	dir = 1
-	},
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
-/area/liberty/bonfire/office)
 "pvV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
@@ -69827,10 +67676,13 @@
 /turf/simulated/floor/asteroid/grass,
 /area/liberty/maintenance/undergroundfloor1oldgarden)
 "pvZ" = (
-/obj/structure/table/woodentable,
-/obj/item/stamp/fr,
-/turf/simulated/floor/tiled/steel/brown_platform,
-/area/liberty/pros/foreman)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/splatter{
+	icon_state = "mgibbl1"
+	},
+/obj/effect/decal/cleanable/blood/drip,
+/turf/simulated/floor/tiled/dark,
+/area/liberty/maintenance/undergroundfloor1east)
 "pwa" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/random/cluster/roaches/lower_chance,
@@ -69914,11 +67766,7 @@
 /area/liberty/maintenance/undergroundfloor2north)
 "pxa" = (
 /obj/machinery/atmospherics/unary/vent_scrubber,
-/obj/effect/floor_decal/border/carpet/red{
-	dir = 1
-	},
-/obj/machinery/space_heater,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "pxd" = (
 /turf/simulated/wall/r_wall,
@@ -70166,8 +68014,8 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/turf/simulated/floor/plating/under,
+/area/liberty/maintenance/undergroundfloor1east)
 "pzN" = (
 /obj/machinery/door/airlock/command{
 	name = "Server Room";
@@ -70264,15 +68112,9 @@
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/liberty/maintenance/undergroundfloor3north)
 "pAO" = (
-/obj/effect/floor_decal/spline/fancy{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/spline/plain{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "pAR" = (
 /obj/random/junk/low_chance,
@@ -70304,14 +68146,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/effect/floor_decal/border/carpet/black/corner{
-	dir = 9
-	},
-/obj/effect/floor_decal/border/carpet/black/corner{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "pBl" = (
 /obj/effect/floor_decal/spline/wood{
@@ -70413,10 +68248,6 @@
 	},
 /turf/simulated/floor/industrial/grey_slates_long,
 /area/liberty/maintenance/undergroundfloor2north)
-"pCA" = (
-/obj/structure/closet/secure_closet/reinforced/oathpledge,
-/turf/simulated/floor/carpet/bcarpet,
-/area/liberty/command/prime)
 "pCD" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8
@@ -70548,23 +68379,6 @@
 	},
 /turf/simulated/floor/tiled/steel/bar_flat,
 /area/liberty/hallway/surface/section1)
-"pEg" = (
-/obj/structure/bookcase,
-/obj/item/book/manual/fiction/littlewomen,
-/obj/item/book/manual/fiction/aroundtheworld,
-/obj/item/book/manual/fiction/muchadoaboutnothing,
-/obj/item/book/manual/fiction/theinvisibleman,
-/obj/item/book/manual/fiction/waroftheworlds,
-/obj/item/book/manual/fiction/thetimemachine,
-/obj/item/book/manual/fiction/thejunglebook,
-/obj/item/book/manual/fiction/rimeoftheancientmariner,
-/obj/item/book/manual/fiction/dracula,
-/obj/effect/floor_decal/border/carpet/red,
-/obj/structure/decor_light/wallcandle{
-	pixel_y = -32
-	},
-/turf/simulated/floor/carpet,
-/area/liberty/bonfire/stronghold)
 "pEh" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume,
 /turf/simulated/floor/tiled/white,
@@ -70602,7 +68416,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel/techfloor_grid,
+/turf/simulated/floor/tiled/dark/gray_platform,
 /area/liberty/crew_quarters/hydroponics)
 "pFe" = (
 /obj/machinery/door/airlock/multi_tile/glass,
@@ -70659,7 +68473,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "pFH" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -70721,13 +68535,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/liberty/maintenance/undergroundfloor3north)
-"pGz" = (
-/obj/structure/table/woodentable,
-/obj/structure/decor_light/wallcandle{
-	pixel_y = 32
-	},
-/turf/simulated/floor/wood,
-/area/liberty/bonfire/vectorrooms)
 "pGC" = (
 /obj/effect/floor_decal/industrial/danger{
 	dir = 1
@@ -70825,9 +68632,10 @@
 	},
 /obj/machinery/air_stopper,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
+/obj/machinery/door/airlock/maintenance_common{
+	req_access = list(12)
 	},
+/turf/simulated/floor/tiled/dark/golden,
 /area/liberty/bonfire/vectorrooms)
 "pHs" = (
 /obj/structure/shuttle_part/science{
@@ -71155,22 +68963,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/spline/fancy{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/spline/fancy{
-	dir = 4
-	},
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 8
-	},
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/bioreactor)
 "pKM" = (
 /obj/machinery/camera/network/command{
@@ -71195,9 +68990,12 @@
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/liberty/medical/cryo)
 "pKR" = (
-/obj/item/bedsheet/browndouble,
-/obj/structure/bed/double/padded,
-/turf/simulated/floor/wood,
+/obj/machinery/shower{
+	dir = 1
+	},
+/obj/structure/curtain/open/shower,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/cafe,
 /area/liberty/bonfire/vectorrooms)
 "pKT" = (
 /obj/machinery/porta_turret/prepper,
@@ -71617,12 +69415,7 @@
 /turf/simulated/floor/reinforced,
 /area/shuttle/vasiliy_shuttle_area)
 "pPu" = (
-/obj/machinery/computer/guestpass{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/structure/decor_headless_2,
-/turf/simulated/floor/tiled/dark/golden,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/hallway/surface/section1)
 "pPv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -71721,19 +69514,6 @@
 /obj/effect/floor_decal/spline/wood,
 /turf/simulated/floor/wood/wild3,
 /area/liberty/crew_quarters)
-"pQB" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/obj/effect/floor_decal/spline/fancy{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/landmark/join/start/forgemaster,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
-/area/liberty/bonfire/bioreactor)
 "pQH" = (
 /obj/machinery/light{
 	dir = 1
@@ -71804,10 +69584,8 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/liberty/engineering/atmos/storage)
 "pRn" = (
-/obj/structure/bed/chair/wood{
-	dir = 8
-	},
-/obj/landmark/join/start/enkindled,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/liberty/bonfire/vectorrooms)
 "pRr" = (
@@ -71871,18 +69649,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/camera/network/custodians,
-/obj/effect/floor_decal/spline/fancy{
-	dir = 1
-	},
-/obj/structure/table/bench/wooden,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks{
+/obj/machinery/light{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "pSd" = (
 /turf/simulated/floor/plating/under,
@@ -72052,9 +69826,7 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 10
 	},
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/bioreactor)
 "pTH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -72174,15 +69946,6 @@
 	},
 /turf/simulated/floor/rock/manmade/road,
 /area/liberty/outside/inside_colony)
-"pUW" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
-/area/liberty/bonfire/stronghold)
 "pVi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -72536,10 +70299,8 @@
 /area/liberty/hallway/surface/section1)
 "pYX" = (
 /obj/structure/table/rack/shelf,
-/obj/item/stack/material/plastic/random,
-/obj/item/stack/material/plastic/random,
 /turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "pYZ" = (
 /obj/random/scrap/dense_even,
 /turf/simulated/floor/rock/alt,
@@ -72757,9 +70518,7 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 8
 	},
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/bioreactor)
 "qbI" = (
 /obj/effect/decal/cleanable/dirt,
@@ -72868,7 +70627,6 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/blood/oil,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/liberty/rnd/robotics)
@@ -72973,22 +70731,6 @@
 /obj/random/closet_tech/low_chance,
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/undergroundfloor1south)
-"qer" = (
-/obj/structure/bed/chair/wood{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/border/carpet/red{
-	dir = 4
-	},
-/obj/effect/floor_decal/border/carpet/red{
-	dir = 1
-	},
-/obj/effect/floor_decal/border/carpet/red{
-	dir = 5
-	},
-/turf/simulated/floor/carpet,
-/area/liberty/bonfire/vectorrooms)
 "qeF" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/cyan{
@@ -73113,24 +70855,13 @@
 /area/liberty/security/maingate)
 "qfG" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/brigdoor/northright{
-	dir = 2;
-	req_access = list(78)
-	},
-/obj/machinery/door/blast/regular{
-	id = "ProspShop"
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/northleft,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/liberty/pros/prep)
-"qfI" = (
-/obj/machinery/door/bonfire{
-	name = "Forge Room"
+/obj/machinery/door/window/northleft{
+	dir = 2
 	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/liberty/bonfire/forge)
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/liberty/maintenance/undergroundfloor1east)
 "qfO" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -73148,19 +70879,16 @@
 /turf/simulated/floor/plating/under,
 /area/liberty/engineering/atmos)
 "qgm" = (
-/obj/machinery/door/airlock/silver{
-	req_access = list(70);
-	name = "Custodians Dormitory"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/wood,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/vectorrooms)
 "qgu" = (
 /obj/structure/barricade,
@@ -73180,10 +70908,6 @@
 /area/shuttle/vasiliy_shuttle_area)
 "qgH" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/mining{
-	name = "Fontaine Prep";
-	req_access = list(78)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -73191,8 +70915,11 @@
 	dir = 4
 	},
 /obj/machinery/air_stopper,
+/obj/machinery/door/airlock/maintenance_common{
+	req_access = list(12)
+	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "qgP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -73466,25 +71193,12 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/liberty/command/gmaster)
-"qjo" = (
-/obj/structure/table/woodentable,
-/obj/machinery/photocopier/faxmachine{
-	department = "Prime's Office"
-	},
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/liberty/command/prime)
 "qjr" = (
 /obj/machinery/alarm{
 	pixel_y = 32
 	},
-/obj/structure/decor_spark_statue,
-/turf/simulated/floor/tiled/dark/golden,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "qjw" = (
 /obj/structure/bed/chair,
@@ -73518,17 +71232,11 @@
 /turf/simulated/floor/industrial/bricks,
 /area/liberty/maintenance/undergroundfloor3north)
 "qjJ" = (
-/obj/effect/floor_decal/spline/fancy{
-	dir = 8
-	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/hologram/holopad,
-/turf/simulated/floor/industrial/greybricks,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "qjN" = (
 /obj/random/scrap/sparse_even/low_chance,
@@ -73579,14 +71287,8 @@
 "qkd" = (
 /obj/structure/table/rack/shelf,
 /obj/item/cell/large/high,
-/obj/item/cell/large/high,
-/obj/item/cell/large/high,
 /obj/item/cell/medium,
 /obj/item/cell/medium,
-/obj/item/cell/medium,
-/obj/item/cell/medium,
-/obj/item/cell/small,
-/obj/item/cell/small,
 /obj/item/cell/small,
 /obj/item/cell/small,
 /obj/item/cell/small,
@@ -73649,18 +71351,13 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/liberty/rnd/lab)
 "qkz" = (
-/obj/item/stool,
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -32
-	},
-/obj/effect/floor_decal/spline/fancy{
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/rack/shelf,
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
-/area/liberty/bonfire/office)
+/turf/simulated/floor/tiled/dark,
+/area/liberty/maintenance/undergroundfloor1east)
 "qkC" = (
 /obj/structure/table/steel,
 /turf/simulated/shuttle/floor/mining{
@@ -73912,10 +71609,7 @@
 "qof" = (
 /obj/effect/floor_decal/spline/fancy,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/torchbearer,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/bioreactor)
 "qoj" = (
 /obj/effect/window_lwall_spawn/reinforced/polarized{
@@ -74199,16 +71893,6 @@
 "qsm" = (
 /turf/simulated/floor/tiled/steel,
 /area/turbolift/mountain/transition2)
-"qsu" = (
-/obj/effect/floor_decal/spline/fancy,
-/obj/machinery/optable/altar,
-/obj/structure/decor_light/wallcandle{
-	pixel_y = 32
-	},
-/turf/simulated/floor/industrial_pristine/greybricks{
-	dir = 1
-	},
-/area/liberty/bonfire/storage)
 "qsD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -74268,9 +71952,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/storage)
 "qte" = (
 /obj/item/trash/plate,
@@ -74302,11 +71984,11 @@
 /turf/simulated/floor/rock/manmade/road,
 /area/liberty/outside/range)
 "qtp" = (
-/obj/effect/window_lwall_spawn/smartspawn/church,
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/liberty/bonfire/stronghold)
 "qtr" = (
@@ -74327,25 +72009,6 @@
 /obj/random/scrap/dense_weighted/low_chance,
 /turf/simulated/floor/industrial/navy_large_slates,
 /area/liberty/maintenance/sunkenclub)
-"qty" = (
-/obj/structure/railing/grey{
-	dir = 4
-	},
-/obj/structure/railing/grey,
-/obj/effect/floor_decal/wood/tatami{
-	dir = 6
-	},
-/obj/structure/railing/grey{
-	dir = 8
-	},
-/obj/structure/closet/crate{
-	name = "target dummies"
-	},
-/obj/item/training_dummy,
-/obj/item/training_dummy,
-/obj/item/training_dummy,
-/turf/simulated/floor/wood/tatami,
-/area/liberty/bonfire/stronghold)
 "qtD" = (
 /obj/machinery/light{
 	dir = 1
@@ -74792,15 +72455,6 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/liberty/crew_quarters/sleep/cryo2)
-"qzb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/spline/fancy{
-	dir = 1
-	},
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
-/area/liberty/bonfire/forge)
 "qzf" = (
 /obj/machinery/light/small,
 /obj/random/traps/low_chance,
@@ -74870,7 +72524,7 @@
 "qzX" = (
 /obj/structure/noticeboard/prospectors,
 /turf/simulated/wall/r_wall,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "qAg" = (
 /obj/machinery/door/airlock/maintenance_medical{
 	name = "Cryogenic Storage";
@@ -74983,11 +72637,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/bricks,
 /area/liberty/maintenance/undergroundfloor2north)
-"qBu" = (
-/obj/structure/table/woodentable,
-/obj/item/storage/fancy/candle_box,
-/turf/simulated/floor/tiled/white/golden,
-/area/liberty/bonfire/forge)
 "qBw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/scrap/food,
@@ -75481,13 +73130,6 @@
 /obj/random/flora/wild/low,
 /turf/simulated/floor/snow,
 /area/liberty/outside/inside_colony)
-"qGw" = (
-/obj/structure/flora/small/grassb3,
-/obj/structure/decor_the_purifier{
-	name = "The Purifier"
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/liberty/bonfire/stronghold)
 "qGz" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "2,7"
@@ -75579,7 +73221,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "qHu" = (
 /obj/structure/grille/broken,
 /obj/structure/boulder,
@@ -75658,11 +73300,14 @@
 /turf/simulated/floor/wood/wild1,
 /area/liberty/crew_quarters/dorm3)
 "qIf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 1
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
 	},
-/turf/simulated/floor/tiled/white/golden,
+/obj/structure/mirror{
+	pixel_x = 28
+	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/vectorrooms)
 "qIg" = (
 /obj/effect/floor_decal/industrial/stand_clear/red{
@@ -75694,13 +73339,6 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/liberty/security/sechall)
-"qIx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/network/fontaine{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
 "qIy" = (
 /turf/simulated/shuttle/wall/science{
 	icon_state = "4,16"
@@ -75779,25 +73417,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance_common{
+	req_access = list(12)
+	},
 /turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "qIS" = (
 /turf/simulated/mineral,
 /area/liberty/dungeon/outside/trashcave)
-"qIW" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/wood,
-/area/liberty/bonfire/vectorrooms)
 "qJb" = (
 /obj/random/spider_trap/low_chance,
 /turf/simulated/floor/rock,
@@ -75971,12 +73598,9 @@
 /turf/simulated/floor/plating/under,
 /area/liberty/maintenance/maint_merc)
 "qLo" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white/golden,
-/area/liberty/bonfire/vectorrooms)
+/obj/landmark/join/start/shepherd,
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/liberty/pros/shuttle)
 "qLs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -76062,18 +73686,6 @@
 /obj/item/computer_hardware/hard_drive/portable/design/misc,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/liberty/command/gmaster)
-"qMJ" = (
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_y = -32
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/decor_light/wallcandle{
-	pixel_y = -32
-	},
-/obj/machinery/space_heater,
-/turf/simulated/floor/wood,
-/area/liberty/bonfire/vectorrooms)
 "qMK" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "10,15";
@@ -76256,19 +73868,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/undergroundfloor1south)
-"qOI" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/industrial_pristine/greybricks{
-	dir = 1
-	},
-/area/liberty/bonfire/alchemist)
 "qOL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/department/armory{
@@ -76322,7 +73921,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
+/obj/machinery/door/airlock/maintenance_common{
+	req_access = list(12)
+	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/storage)
 "qOW" = (
 /obj/structure/multiz/stairs/enter/bottom{
@@ -76400,21 +74002,9 @@
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/liberty/command/meeting_room)
 "qPJ" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/spline/fancy{
-	dir = 1
-	},
-/obj/effect/floor_decal/spline/fancy,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/spline/fancy,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
-/area/liberty/bonfire/bioreactor)
+/obj/machinery/washing_machine,
+/turf/simulated/floor/tiled/dark,
+/area/liberty/bonfire/vectorrooms)
 "qPP" = (
 /obj/effect/floor_decal/industrial/danger,
 /obj/structure/window/reinforced,
@@ -76476,22 +74066,6 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/maint_merc)
-"qQv" = (
-/obj/structure/bed/chair/comfy/brown{
-	dir = 4
-	},
-/obj/effect/floor_decal/border/carpet/red{
-	dir = 1
-	},
-/obj/structure/decor_light/wallcandle{
-	pixel_y = 32
-	},
-/obj/landmark/join/start/enkindled,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/carpet,
-/area/liberty/bonfire/stronghold)
 "qQB" = (
 /obj/structure/bed/chair/wood{
 	dir = 1
@@ -76529,12 +74103,8 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/suit_storage_unit/nt/flameshield,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/effect/floor_decal/spline/fancy{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/golden,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/storage)
 "qRq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -76618,13 +74188,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/liberty/maintenance/undergroundfloor3north)
-"qSH" = (
-/obj/structure/closet/wardrobe/misc/pjs,
-/obj/machinery/camera/network/custodians{
-	dir = 8
-	},
-/turf/simulated/floor/wood,
-/area/liberty/bonfire/vectorrooms)
 "qSP" = (
 /obj/machinery/camera/network/colony_surface,
 /turf/simulated/floor/wood/wild1,
@@ -76917,15 +74480,6 @@
 /obj/structure/closet/secure_closet/personal/scientist,
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/rnd/lab)
-"qVN" = (
-/obj/machinery/power/torchbearer,
-/obj/effect/floor_decal/spline/fancy/cee{
-	dir = 1
-	},
-/turf/simulated/floor/industrial_pristine/greybricks{
-	dir = 1
-	},
-/area/liberty/bonfire/forge)
 "qVQ" = (
 /obj/structure/barricade,
 /turf/simulated/floor/plating/under,
@@ -76950,13 +74504,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/liberty/rnd/xenoflora)
-"qWl" = (
-/obj/effect/floor_decal/spline/fancy,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
-/area/liberty/bonfire/stronghold)
 "qWo" = (
 /obj/structure/table/rack,
 /obj/machinery/door/window/southleft{
@@ -77150,19 +74697,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/liberty/engineering/foyer)
-"qYZ" = (
-/obj/machinery/computer/arcade,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/liberty/bonfire/vectorrooms)
 "qZs" = (
 /obj/machinery/door/airlock/multi_tile/metal/mait{
 	dir = 2
@@ -77415,26 +74949,13 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 1
-	},
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 8
-	},
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 9
-	},
-/obj/effect/floor_decal/border/carpet/black/corner{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/tiled/dark/golden,
 /area/liberty/bonfire/storage)
 "rby" = (
 /obj/machinery/disposal,
@@ -77462,15 +74983,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 4
-	},
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 8
-	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "rbS" = (
 /obj/structure/plushie/drone,
@@ -77617,16 +75131,23 @@
 "rdY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/spline/fancy,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/bioreactor)
 "reg" = (
-/obj/machinery/smartfridge/kitchen/custodians,
-/turf/simulated/floor/industrial_pristine/greybricks{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/area/liberty/bonfire/alchemist)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance_common{
+	req_access = list(12)
+	},
+/turf/simulated/floor/wood,
+/area/liberty/bonfire/vectorrooms)
 "ren" = (
 /obj/effect/window_lwall_spawn/reinforced/polarized{
 	id = "CSO"
@@ -77965,10 +75486,7 @@
 /area/liberty/quartermaster/vault)
 "rhK" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/vectorrooms)
 "rhT" = (
 /obj/structure/table/steel,
@@ -78423,13 +75941,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/undergroundfloor2west)
-"rmT" = (
-/obj/structure/flora/ausbushes/leafybush,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/liberty/bonfire/stronghold)
 "rmU" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 1
@@ -78484,33 +75995,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
 /area/liberty/maintenance/undergroundfloor2east)
-"rnw" = (
-/obj/effect/window_lwall_spawn/reinforced,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating/under,
-/area/liberty/pros/prep)
 "rnF" = (
 /obj/random/pack/junk_machine,
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/liberty/maintenance/undergroundfloor2south)
-"rnK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/industrial_pristine/greybricks{
-	dir = 1
-	},
-/area/liberty/bonfire/alchemist)
 "rnM" = (
 /obj/structure/table/woodentable,
 /obj/item/pen{
@@ -78532,27 +76022,6 @@
 /obj/structure/cable/yellow,
 /turf/simulated/floor/plating/under,
 /area/liberty/engineering/engine_room)
-"rnQ" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/spline/fancy{
-	dir = 1
-	},
-/obj/effect/floor_decal/spline/fancy,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
-/area/liberty/bonfire/stronghold)
 "rnV" = (
 /obj/machinery/space_heater,
 /obj/structure/sign/painting/paintingsunset{
@@ -78828,7 +76297,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "rsI" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /obj/structure/railing{
@@ -78904,9 +76373,6 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/liberty/maintenance/undergroundfloor3north)
 "rtw" = (
-/obj/effect/floor_decal/spline/fancy{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -78914,9 +76380,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "rtB" = (
 /obj/machinery/light/small{
@@ -78940,7 +76404,6 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/oldarmory)
 "rtE" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 2;
@@ -78950,14 +76413,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 4
-	},
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "rtF" = (
 /obj/random/scrap/sparse_weighted,
@@ -79049,7 +76505,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "ruL" = (
 /turf/simulated/floor/tiled/dark,
 /area/liberty/crew_quarters/sleep/cryo2)
@@ -79237,22 +76693,6 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/liberty/engineering/engine_waste)
-"rwB" = (
-/obj/structure/closet/wall_mounted/firecloset{
-	pixel_y = -32
-	},
-/obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warningred,
-/obj/structure/decor_light/wallcandle{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/white/golden,
-/area/liberty/bonfire/vectorrooms)
 "rwC" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
@@ -79511,10 +76951,6 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/liberty/hallway/surface/section1)
-"ryJ" = (
-/obj/structure/decor_headless_3,
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/hallway/surface/section1)
 "ryO" = (
 /obj/machinery/chem_master,
 /turf/simulated/floor/tiled/white/brown_perforated,
@@ -79552,11 +76988,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/undergroundfloor2west)
-"rzh" = (
-/obj/structure/table/woodentable,
-/obj/item/paper_bin,
-/turf/simulated/floor/carpet,
-/area/liberty/bonfire/vectorrooms)
 "rzi" = (
 /obj/structure/noticeboard/research{
 	pixel_y = -32
@@ -79574,19 +77005,6 @@
 /obj/structure/railing,
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/liberty/crew_quarters/bar)
-"rzm" = (
-/obj/structure/mirror{
-	pixel_y = -28
-	},
-/obj/structure/sink{
-	pixel_y = -22
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white/golden,
-/area/liberty/bonfire/vectorrooms)
 "rzD" = (
 /obj/machinery/power/port_gen/pacman/diesel/anchored,
 /obj/structure/cable/yellow{
@@ -79615,13 +77033,6 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/maint_merc)
 "rzR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 8
-	},
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 1
 	},
@@ -79631,7 +77042,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/tiled/dark/golden,
 /area/liberty/bonfire/storage)
 "rzS" = (
 /obj/effect/floor_decal/industrial_plant/steel_grate_warning,
@@ -79845,10 +77256,10 @@
 /turf/simulated/floor/plating/under,
 /area/liberty/engineering/engine_room)
 "rCM" = (
-/obj/structure/bed/chair,
-/obj/landmark/join/start/shepherd,
-/turf/simulated/floor/carpet,
-/area/liberty/pros/foreman)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/drip,
+/turf/simulated/floor/tiled/dark,
+/area/liberty/maintenance/undergroundfloor1east)
 "rCR" = (
 /obj/machinery/power/apc{
 	locked = 0;
@@ -79939,15 +77350,11 @@
 /area/liberty/maintenance/undergroundfloor3south)
 "rDK" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 1
+/obj/effect/floor_decal/spline/fancy{
+	dir = 4
 	},
-/obj/structure/noticeboard/church{
-	pixel_y = 32
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/bcarpet,
-/area/liberty/bonfire/forge)
+/turf/simulated/floor/tiled/dark,
+/area/liberty/bonfire/stronghold)
 "rDO" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -80470,13 +77877,6 @@
 /obj/effect/floor_decal/industrial/danger,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/liberty/medical/genetics)
-"rLC" = (
-/obj/machinery/sewing_artificer,
-/obj/machinery/conveyor/south{
-	id = "bonfire1"
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/bioreactor)
 "rLD" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -80633,11 +78033,11 @@
 /turf/simulated/floor/plating/under,
 /area/liberty/maintenance/undergroundfloor3north)
 "rOb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/wood,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/vectorrooms)
 "rOc" = (
 /obj/structure/window/reinforced/crescent{
@@ -80743,12 +78143,11 @@
 /turf/simulated/floor/rock/manmade/road,
 /area/liberty/outside/forest)
 "rOO" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/vectorrooms)
 "rOW" = (
 /obj/structure/table/steel_reinforced,
@@ -80771,12 +78170,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/ceramic,
 /area/liberty/maintenance/oldpool)
-"rPk" = (
-/obj/effect/floor_decal/wood/tatami{
-	dir = 9
-	},
-/turf/simulated/floor/wood/tatami,
-/area/liberty/bonfire/stronghold)
 "rPn" = (
 /obj/structure/catwalk,
 /obj/structure/railing{
@@ -80884,8 +78277,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/maintenance_common{
+	req_access = list(12)
+	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "rQP" = (
 /obj/structure/bed/chair/comfy/blue{
 	dir = 1
@@ -80916,14 +78312,6 @@
 /obj/random/mob/termite_no_despawn,
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/undergroundfloor2south)
-"rRu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/sewing_artificer/composite_artificer,
-/obj/machinery/conveyor/south{
-	id = "bonfire2"
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/bioreactor)
 "rRv" = (
 /obj/machinery/door/airlock/command{
 	id_tag = "wobolt1";
@@ -81017,12 +78405,10 @@
 /area/liberty/maintenance/undergroundfloor2south)
 "rSM" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/landmark/join/start/enkindled,
-/obj/effect/floor_decal/spline/fancy,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
-/area/liberty/bonfire/office)
+/obj/effect/decal/cleanable/dirt,
+/obj/random/mob/spiders/low_chance,
+/turf/simulated/floor/tiled/dark,
+/area/liberty/maintenance/undergroundfloor1east)
 "rSO" = (
 /obj/structure/low_wall,
 /obj/machinery/door/blast/regular{
@@ -81129,15 +78515,9 @@
 /turf/simulated/floor/industrial/grey_slates,
 /area/liberty/maintenance/undergroundfloor3north)
 "rTA" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/spline/fancy,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
-/area/liberty/bonfire/office)
+/obj/landmark/join/start/forgemaster,
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/liberty/pros/shuttle)
 "rTE" = (
 /obj/structure/table/standard,
 /obj/machinery/cash_register{
@@ -81377,9 +78757,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/storage)
 "rWO" = (
 /obj/structure/bed/chair/office/light{
@@ -81543,7 +78921,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "rYL" = (
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/wall/rust_standard,
@@ -81577,22 +78955,6 @@
 	icon_state = "12,1"
 	},
 /area/shuttle/vasiliy_shuttle_area)
-"rZo" = (
-/obj/structure/bookcase,
-/obj/effect/floor_decal/border/carpet/red{
-	dir = 1
-	},
-/obj/effect/floor_decal/border/carpet/red{
-	dir = 4
-	},
-/obj/effect/floor_decal/border/carpet/red{
-	dir = 5
-	},
-/obj/item/book/lectures/hearthlantern,
-/obj/item/book/lectures/hearthlantern,
-/obj/item/book/lectures/hearthlantern,
-/turf/simulated/floor/carpet,
-/area/liberty/bonfire/stronghold)
 "rZp" = (
 /obj/item/flame/candle,
 /turf/simulated/floor/rock/manmade/concrete,
@@ -81967,20 +79329,16 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/wood/wild1,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "scx" = (
 /obj/machinery/light,
-/obj/effect/floor_decal/spline/fancy,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/table/bench/wooden,
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
 	},
 /obj/effect/floor_decal/industrial/warningred,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "scC" = (
 /obj/structure/bed/chair/sofa/teal/corner{
@@ -82138,12 +79496,6 @@
 /mob/living/simple_animal/pig/hog,
 /turf/simulated/floor/asteroid/grass,
 /area/liberty/crew_quarters/hydroponics)
-"sdm" = (
-/obj/effect/floor_decal/wood/tatami{
-	dir = 6
-	},
-/turf/simulated/floor/wood/tatami,
-/area/liberty/bonfire/stronghold)
 "sdu" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt/snow,
@@ -82602,8 +79954,8 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/bonfire{
-	name = "Forge Room"
+/obj/machinery/door/airlock/maintenance_common{
+	req_access = list(12)
 	},
 /turf/simulated/floor/plating,
 /area/liberty/bonfire/bioreactor)
@@ -83256,12 +80608,6 @@
 /obj/structure/flora/small/busha1,
 /turf/simulated/floor/asteroid/grass,
 /area/liberty/hallway/side/f2section1)
-"spK" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/table/rack,
-/obj/item/flame/lighter/zippo/bonfire,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/liberty/bonfire/forge)
 "spL" = (
 /obj/machinery/door/blast/regular{
 	id = "Cell 3b";
@@ -83283,23 +80629,6 @@
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/liberty/command/courtroom)
-"spS" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 1
-	},
-/obj/effect/floor_decal/border/carpet/black,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/liberty/bonfire/stronghold)
 "spV" = (
 /obj/machinery/autolathe/mechfab/loaded,
 /obj/structure/boulder,
@@ -83312,18 +80641,13 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 1
-	},
-/obj/effect/floor_decal/border/carpet/black,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "spX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -83382,10 +80706,9 @@
 /turf/simulated/floor/industrial/white_large_slates,
 /area/liberty/maintenance/undergroundfloor3south)
 "sra" = (
-/obj/structure/table/rack/shelf,
-/obj/random/gun_parts/frames,
+/obj/structure/table/standard,
 /turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "sre" = (
 /obj/machinery/camera/network/custodians,
 /obj/structure/cable/cyan{
@@ -83446,12 +80769,11 @@
 /turf/simulated/floor/wood/wild5,
 /area/liberty/dungeon/outside/campground)
 "srP" = (
-/obj/structure/table/woodentable,
-/obj/machinery/photocopier/faxmachine{
-	department = "Foreman's Office"
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/steel/brown_platform,
-/area/liberty/pros/foreman)
+/turf/simulated/floor/tiled/dark,
+/area/liberty/maintenance/undergroundfloor1east)
 "srQ" = (
 /obj/item/spider_shadow_trap/burrowing,
 /turf/simulated/floor/rock,
@@ -83589,15 +80911,17 @@
 /turf/simulated/floor/wood/wild3,
 /area/liberty/crew_quarters)
 "stC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
+/obj/structure/disposalpipe/junction{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
-/turf/simulated/floor/wood,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/vectorrooms)
 "stE" = (
 /obj/effect/floor_decal/industrial/warning,
@@ -83793,28 +81117,15 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/undergroundfloor1south)
 "swr" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/wood,
-/area/liberty/bonfire/vectorrooms)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/liberty/bonfire/stronghold)
 "swE" = (
 /obj/structure/sign/warning/nosmoking/small{
 	pixel_x = -25
@@ -83834,8 +81145,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/sandbags{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "swW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -84149,22 +81463,11 @@
 /obj/item/computer_hardware/hard_drive/portable/design/misc,
 /obj/structure/table/steel,
 /obj/random/lathe_disk,
-/obj/random/lathe_disk,
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
-"sAi" = (
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	pixel_y = 32
-	},
-/obj/effect/floor_decal/industrial/arrows/white{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white/golden,
-/area/liberty/bonfire/vectorrooms)
+/area/liberty/maintenance/undergroundfloor1east)
 "sAp" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -84285,16 +81588,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/liberty/quartermaster/hangarsupply)
-"sBo" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet,
-/area/liberty/bonfire/stronghold)
 "sBq" = (
 /obj/structure/reagent_dispensers/premiumwhiskey,
 /turf/simulated/floor/tiled/white/brown_platform,
@@ -84684,15 +81977,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/decor_light/wallcandle{
-	pixel_y = 32
-	},
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
 	},
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark/golden,
 /area/liberty/bonfire/vectorrooms)
 "sFd" = (
 /obj/structure/disposalpipe/segment{
@@ -84779,27 +82067,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/liberty/security/detectives_office)
-"sFJ" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 4
-	},
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/liberty/bonfire/stronghold)
 "sFL" = (
 /obj/random/junk/low_chance,
 /obj/item/contraband/poster/placed/generic/walk{
@@ -84880,27 +82147,6 @@
 	},
 /turf/simulated/floor/tiled/dark/cargo,
 /area/shuttle/surface_transport_lz)
-"sGB" = (
-/obj/machinery/door/bonfire{
-	name = "Forge Room"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/liberty/bonfire/forge)
 "sGJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -85268,8 +82514,12 @@
 	pixel_y = 32
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet,
-/area/liberty/pros/foreman)
+/obj/structure/bed/roller,
+/obj/effect/decal/cleanable/blood/splatter{
+	icon_state = "gib2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/liberty/maintenance/undergroundfloor1east)
 "sKG" = (
 /turf/simulated/wall/r_wall,
 /area/liberty/rnd/xenobiology)
@@ -85427,11 +82677,6 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "West APC";
-	pixel_x = -28
-	},
 /obj/structure/closet/wall_mounted/firecloset{
 	pixel_y = -32
 	},
@@ -85442,8 +82687,12 @@
 /obj/effect/floor_decal/industrial/box/red/corners{
 	dir = 8
 	},
+/obj/machinery/power/apc/inactive{
+	name = "West APC";
+	pixel_x = -28
+	},
 /turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "sMD" = (
 /obj/random/scrap/dense_weighted/low_chance,
 /turf/simulated/floor/tiled/techmaint,
@@ -85516,15 +82765,13 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "sNx" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/bioreactor)
 "sNB" = (
 /obj/structure/table/woodentable,
@@ -85562,7 +82809,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/brown_platform,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "sNP" = (
 /obj/effect/window_lwall_spawn/reinforced/polarized{
 	id = "EYE"
@@ -85670,7 +82917,7 @@
 /turf/simulated/floor/industrial/navy_slates,
 /area/liberty/maintenance/sunkenclub)
 "sPV" = (
-/turf/simulated/wall/church_reinforced,
+/turf/simulated/wall/r_wall,
 /area/liberty/bonfire/stronghold)
 "sQd" = (
 /obj/landmark/join/start/janitor,
@@ -85817,7 +83064,7 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 4
 	},
-/turf/simulated/floor/industrial/greybricks,
+/turf/simulated/floor/tiled/dark/golden,
 /area/liberty/bonfire/bioreactor)
 "sRV" = (
 /obj/structure/catwalk,
@@ -85911,7 +83158,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark/golden,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/hallway/surface/section1)
 "sSz" = (
 /obj/structure/kitchenspike,
@@ -85947,7 +83194,10 @@
 "sSV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/portable_atmospherics/hydroponics,
-/turf/simulated/floor/tiled/dark/gray_platform,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/gray_perforated,
 /area/liberty/crew_quarters/hydroponics)
 "sSW" = (
 /obj/structure/table/steel,
@@ -85998,7 +83248,7 @@
 /area/liberty/maintenance/undergroundfloor2east)
 "sTC" = (
 /turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "sTG" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/item/tool/pickaxe{
@@ -86064,7 +83314,7 @@
 /obj/structure/table/steel,
 /obj/machinery/recharger,
 /turf/simulated/floor/tiled/steel/gray_perforated,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "sUt" = (
 /turf/simulated/floor/tiled/dark/panels,
 /area/liberty/pros/shuttle)
@@ -86135,6 +83385,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/table/standard,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/liberty/command/gmaster)
 "sVr" = (
@@ -86167,11 +83418,8 @@
 	dir = 1
 	},
 /obj/machinery/light,
-/obj/machinery/computer/guestpass{
-	pixel_y = -32
-	},
 /turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "sVF" = (
 /turf/simulated/wall/r_wall,
 /area/liberty/quartermaster/hangarsupply)
@@ -86347,29 +83595,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/liberty/storage/primary)
-"sXH" = (
-/obj/structure/railing/grey{
-	dir = 4
-	},
-/obj/structure/table/rack,
-/obj/effect/floor_decal/wood/tatami{
-	dir = 4
-	},
-/obj/item/melee_training/staff,
-/obj/item/melee_training/staff,
-/obj/item/melee_training/spear,
-/obj/item/melee_training/spear,
-/turf/simulated/floor/wood/tatami,
-/area/liberty/bonfire/stronghold)
 "sXK" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/asteroid/grass,
 /area/liberty/hallway/side/f2section1)
 "sYa" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/storage)
 "sYf" = (
 /turf/simulated/wall/r_wall,
@@ -86705,14 +83937,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/spline/plain,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "tcI" = (
 /obj/structure/cable/cyan{
@@ -86751,14 +83977,12 @@
 	},
 /area/liberty/rnd/server)
 "tcU" = (
-/obj/effect/floor_decal/spline/fancy,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/golden,
+/turf/simulated/floor/plating/under,
 /area/liberty/bonfire/storage)
 "tcV" = (
 /obj/structure/bed/chair/office/light,
@@ -86836,16 +84060,10 @@
 /turf/simulated/floor/carpet/turcarpet,
 /area/liberty/medical/psych)
 "tdM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/industrial/loading/white{
-	dir = 4
-	},
 /obj/effect/floor_decal/spline/fancy{
 	dir = 8
 	},
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/bioreactor)
 "tdO" = (
 /obj/structure/cable/green{
@@ -86999,11 +84217,10 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/liberty/command/gmaster)
 "teT" = (
-/obj/structure/table/woodentable,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/simulated/floor/tiled/steel/brown_platform,
-/area/liberty/pros/foreman)
+/obj/effect/decal/cleanable/dirt,
+/obj/item/cell/large/high,
+/turf/simulated/floor/plating/under,
+/area/liberty/maintenance/undergroundfloor1east)
 "tfg" = (
 /obj/random/closet_maintloot,
 /obj/effect/decal/cleanable/dirt,
@@ -87021,9 +84238,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/bioreactor)
 "tfm" = (
 /obj/structure/window/reinforced{
@@ -87103,12 +84318,20 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/maint_merc)
 "tgI" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/disposalpipe/segment{
+	dir = 8
 	},
-/turf/simulated/floor/wood,
+/obj/structure/disposalpipe/junction{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/vectorrooms)
 "tgT" = (
 /obj/machinery/light_switch{
@@ -87228,10 +84451,6 @@
 /turf/simulated/floor/tiled/dark/danger,
 /area/liberty/command/teleporter)
 "tir" = (
-/obj/machinery/door/airlock/glass{
-	name = "Hydroponics";
-	req_access = list(35)
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -87247,6 +84466,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/liberty/crew_quarters/hydroponics)
 "tix" = (
@@ -87440,23 +84660,6 @@
 /obj/structure/salvageable/server,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/liberty/engineering/atmos/storage)
-"tkS" = (
-/obj/structure/bed/chair/wood{
-	dir = 4;
-	tag = "icon-wooden_chair (EAST)"
-	},
-/obj/effect/floor_decal/border/carpet/red{
-	dir = 8
-	},
-/obj/effect/floor_decal/border/carpet/red{
-	dir = 1
-	},
-/obj/effect/floor_decal/border/carpet/red{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet,
-/area/liberty/bonfire/vectorrooms)
 "tkV" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -87479,19 +84682,6 @@
 /obj/structure/scrap_cube,
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/engineering/atmos/storage)
-"tli" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/table/rack,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -32
-	},
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/tool/saw,
-/obj/item/tool/hammer,
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/forge)
 "tlj" = (
 /obj/structure/flora/small/snow/rock2,
 /obj/structure/flora/tree/snow/five,
@@ -87782,9 +84972,7 @@
 	dir = 5
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/storage)
 "toX" = (
 /obj/machinery/power/apc{
@@ -87834,19 +85022,10 @@
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/liberty/maintenance/undergroundfloor2north)
 "tpI" = (
-/obj/structure/decor_headless_1,
-/obj/structure/decor_light/wallcandle{
-	pixel_y = -32
-	},
 /obj/effect/floor_decal/spline/fancy{
 	dir = 10
 	},
-/obj/machinery/camera/network/custodians{
-	dir = 4
-	},
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark/golden,
 /area/liberty/bonfire/vectorrooms)
 "tpJ" = (
 /obj/random/scrap/dense_weighted/low_chance,
@@ -87945,9 +85124,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/bioreactor)
 "tqu" = (
 /obj/effect/decal/cleanable/dirt,
@@ -88101,19 +85278,13 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 4
-	},
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 8
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "trV" = (
 /obj/structure/table/rack/shelf,
@@ -88136,22 +85307,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/spline/fancy{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/spline/fancy{
-	dir = 4
-	},
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 8
-	},
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/bioreactor)
 "tsb" = (
 /obj/effect/floor_decal/industrial/loading/white{
@@ -88313,7 +85471,7 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/liberty/command/captain/quarters)
 "ttZ" = (
-/turf/simulated/wall/church_reinforced,
+/turf/simulated/wall/r_wall,
 /area/liberty/bonfire/bioreactor)
 "tuc" = (
 /obj/structure/shuttle_part/science{
@@ -88557,7 +85715,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/sblucarpet,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "txi" = (
 /obj/machinery/photocopier,
 /turf/simulated/floor/tiled/steel,
@@ -88625,10 +85783,6 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/liberty/engineering/atmos)
 "txN" = (
-/obj/machinery/door/airlock/silver{
-	req_access = list(27);
-	name = "Custodians Commons"
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -88636,9 +85790,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
+/obj/machinery/door/airlock/maintenance_common{
+	req_access = list(12)
 	},
+/turf/simulated/floor/tiled/dark/golden,
 /area/liberty/bonfire/vectorrooms)
 "txQ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -88678,11 +85833,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/bonfire{
-	name = "Custodians substation"
-	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
+/obj/machinery/door/airlock/maintenance_common{
+	req_access = list(12)
+	},
+/turf/simulated/floor/tiled/dark/golden,
 /area/liberty/bonfire/storage)
 "tym" = (
 /obj/structure/bed/chair/comfy/brown{
@@ -88782,24 +85937,6 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/liberty/medical/reception)
-"tzL" = (
-/obj/machinery/camera/network/custodians{
-	dir = 1
-	},
-/obj/effect/floor_decal/border/carpet/red{
-	dir = 4
-	},
-/obj/effect/floor_decal/border/carpet/red{
-	dir = 8
-	},
-/obj/effect/floor_decal/border/carpet/red{
-	dir = 10
-	},
-/obj/effect/floor_decal/border/carpet/red{
-	dir = 6
-	},
-/turf/simulated/floor/carpet,
-/area/liberty/hallway/surface/section1)
 "tzX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm{
@@ -88824,8 +85961,8 @@
 "tAf" = (
 /obj/machinery/atmospherics/unary/vent_pump,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood/wild3,
-/area/liberty/pros/foreman)
+/turf/simulated/floor/tiled/dark,
+/area/liberty/maintenance/undergroundfloor1east)
 "tAj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -88931,15 +86068,9 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/undergroundfloor3east)
 "tBR" = (
-/obj/structure/table/woodentable,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/item/stamp/pr,
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/liberty/command/prime)
+/obj/landmark/join/start/trapper,
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/liberty/pros/shuttle)
 "tCb" = (
 /obj/effect/decal/cleanable/dirt/snow,
 /obj/random/cluster/termite_no_despawn/low_chance,
@@ -89022,8 +86153,11 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance_common{
+	req_access = list(12)
+	},
 /turf/simulated/floor/tiled/dark,
-/area/liberty/pros/foreman)
+/area/liberty/maintenance/undergroundfloor1east)
 "tDl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -89330,7 +86464,7 @@
 /obj/structure/table/gamblingtable,
 /obj/item/deck/cards,
 /turf/simulated/floor/carpet/sblucarpet,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "tGp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -89449,27 +86583,6 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/liberty/crew_quarters/sleep/cryo2)
-"tGV" = (
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/obj/structure/railing/grey{
-	dir = 8
-	},
-/obj/effect/floor_decal/wood/tatami{
-	dir = 9
-	},
-/obj/structure/railing/grey{
-	dir = 4
-	},
-/obj/structure/closet/crate{
-	name = "target dummies"
-	},
-/obj/item/training_dummy/cultist,
-/obj/item/training_dummy/merc,
-/obj/item/training_dummy/wingchun,
-/turf/simulated/floor/wood/tatami,
-/area/liberty/bonfire/stronghold)
 "tGY" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/yellow,
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -89531,15 +86644,17 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/command/panic_room)
 "tHU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white/golden,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/vectorrooms)
 "tHX" = (
 /obj/random/mob/termite_no_despawn,
@@ -89622,13 +86737,10 @@
 /obj/random/traps/low_chance,
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/oldmining)
-"tIX" = (
-/obj/effect/floor_decal/wood/tatami,
-/turf/simulated/floor/wood/tatami,
-/area/liberty/bonfire/stronghold)
 "tJm" = (
-/obj/structure/bed/double/padded,
-/obj/item/bedsheet/browndouble,
+/obj/structure/bed,
+/obj/item/bedsheet/mime,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/liberty/bonfire/vectorrooms)
 "tJo" = (
@@ -89845,7 +86957,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "tLj" = (
 /obj/structure/table/rack/shelf,
 /obj/random/mecha_utility,
@@ -90095,8 +87207,9 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/random/mob/spiders/low_chance,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "tOK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/extinguisher_cabinet{
@@ -90445,9 +87558,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/storage)
 "tSe" = (
 /obj/structure/table/reinforced,
@@ -90597,10 +87708,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
-"tUJ" = (
-/turf/simulated/wall/church_reinforced,
-/area/liberty/command/prime)
+/area/liberty/maintenance/undergroundfloor1east)
 "tUP" = (
 /obj/structure/cable/green{
 	d2 = 4;
@@ -90899,9 +88007,7 @@
 "tYy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark/golden,
 /area/liberty/bonfire/vectorrooms)
 "tYC" = (
 /obj/structure/cable/green{
@@ -90933,18 +88039,6 @@
 /obj/random/cluster/termite_no_despawn/low_chance,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/liberty/maintenance/undergroundfloor3south)
-"tYM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/wood,
-/area/liberty/bonfire/vectorrooms)
 "tYP" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
@@ -91029,17 +88123,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/effect/floor_decal/spline/fancy/corner{
-	dir = 8
-	},
-/obj/effect/floor_decal/spline/fancy/corner{
-	dir = 4
-	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "tZD" = (
 /obj/effect/decal/cleanable/dirt,
@@ -91167,8 +88251,8 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/steel/brown_perforated,
-/area/liberty/pros/foreman)
+/turf/simulated/floor/plating/under,
+/area/liberty/maintenance/undergroundfloor1east)
 "ubm" = (
 /obj/structure/showcase/skeleton{
 	name = "Dr. Bones Skellington";
@@ -91383,11 +88467,10 @@
 /turf/simulated/floor/wood/wild3,
 /area/liberty/crew_quarters/bar)
 "uec" = (
-/obj/machinery/portable_atmospherics/hydroponics,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/turf/simulated/floor/tiled/steel/techfloor_grid,
+/turf/simulated/floor/tiled/dark/gray_platform,
 /area/liberty/crew_quarters/hydroponics)
 "ueg" = (
 /obj/structure/cable/cyan{
@@ -91669,13 +88752,6 @@
 	icon_state = "1,17"
 	},
 /area/shuttle/rocinante_shuttle_area)
-"ugU" = (
-/obj/effect/floor_decal/spline/plain,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
-/area/liberty/bonfire/stronghold)
 "uhb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/newscaster{
@@ -91755,16 +88831,10 @@
 /turf/simulated/floor/industrial/ornate,
 /area/liberty/maintenance/bank)
 "uhK" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "uhM" = (
 /obj/machinery/space_heater,
@@ -91898,8 +88968,9 @@
 /area/liberty/maintenance/undergroundfloor3north)
 "uiZ" = (
 /obj/random/furniture/pottedplant,
-/turf/simulated/floor/wood/wild3,
-/area/liberty/pros/foreman)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/liberty/maintenance/undergroundfloor1east)
 "uji" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -92274,8 +89345,7 @@
 /area/liberty/engineering/engine_room)
 "unb" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/reagent_dispensers/cahorsbarrel,
-/turf/simulated/floor/tiled/dark/golden,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/storage)
 "uni" = (
 /obj/effect/floor_decal/spline/plain,
@@ -92285,11 +89355,9 @@
 /turf/simulated/floor/industrial/blue_slates_long,
 /area/liberty/maintenance/oldpool)
 "unl" = (
-/obj/item/stool,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/network/fontaine,
 /turf/simulated/floor/tiled/steel/brown_platform,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "unn" = (
 /obj/item/remains/human,
 /obj/item/clothing/head/helmet/ballistic,
@@ -92398,11 +89466,6 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating/under,
 /area/liberty/maintenance/maint_merc)
-"uoZ" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/wood,
-/area/liberty/bonfire/vectorrooms)
 "upe" = (
 /obj/structure/boulder,
 /turf/simulated/floor/plating/under,
@@ -92550,17 +89613,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/effect/floor_decal/spline/fancy/corner,
-/obj/effect/floor_decal/spline/plain/corner{
-	dir = 4
-	},
-/obj/effect/floor_decal/spline/fancy/corner{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "uqL" = (
 /obj/machinery/atmospherics/unary/vent_pump{
@@ -92837,8 +89890,8 @@
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/liberty/hallway/surface/section1)
 "utS" = (
-/obj/effect/window_lwall_spawn/smartspawn/church,
 /obj/machinery/door/firedoor,
+/obj/effect/window_lwall_spawn/smartspawn,
 /turf/simulated/floor/plating,
 /area/liberty/bonfire/vectorrooms)
 "utT" = (
@@ -93126,13 +90179,12 @@
 /area/liberty/security/main)
 "uxT" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/trashcart,
 /obj/effect/floor_decal/industrial/warningred,
 /obj/structure/closet/wall_mounted/firecloset{
 	pixel_y = -32
 	},
 /turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "uxX" = (
 /turf/simulated/shuttle/wall/science{
 	icon_state = "9,16"
@@ -93251,10 +90303,10 @@
 /turf/simulated/floor/asteroid/grass,
 /area/liberty/hallway/side/f2section1)
 "uzb" = (
-/obj/structure/closet/secure_closet/personal/shipbreaker,
 /obj/structure/window/reinforced,
+/obj/structure/closet/random_milsupply,
 /turf/simulated/floor/tiled/white/techfloor_grid,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "uze" = (
 /obj/item/storage/box/donkpockets,
 /obj/structure/table/standard,
@@ -93266,7 +90318,7 @@
 	pixel_x = 26
 	},
 /turf/simulated/floor/tiled/white/techfloor_grid,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "uzk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/cluster/spiders/low_chance,
@@ -93274,7 +90326,6 @@
 /area/liberty/maintenance/undergroundfloor1east)
 "uzo" = (
 /obj/machinery/mech_recharger,
-/obj/random/mecha/low_chance,
 /obj/structure/sign/warning/nosmoking/small{
 	pixel_x = -25
 	},
@@ -93320,20 +90371,11 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "uzz" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/cafe_large,
 /area/liberty/maintenance/oldkitchen)
-"uzA" = (
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/obj/effect/floor_decal/wood/tatami{
-	dir = 1
-	},
-/turf/simulated/floor/wood/tatami,
-/area/liberty/bonfire/stronghold)
 "uzD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -93391,16 +90433,12 @@
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/liberty/outside/inside_colony)
 "uzU" = (
-/obj/effect/floor_decal/border/carpet/black{
+/obj/machinery/recharge_station,
+/obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/floor_decal/border/carpet/black,
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/bcarpet,
-/area/liberty/bonfire/forge)
+/turf/simulated/floor/tiled/dark,
+/area/liberty/bonfire/vectorrooms)
 "uzX" = (
 /obj/item/storage/firstaid,
 /obj/item/reagent_containers/syringe/drugs_recreational,
@@ -93582,13 +90620,10 @@
 /turf/simulated/floor/carpet/turcarpet,
 /area/liberty/command/captain/quarters)
 "uCn" = (
-/obj/machinery/vending/theomat,
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
 	},
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark/golden,
 /area/liberty/bonfire/vectorrooms)
 "uCt" = (
 /obj/machinery/door/airlock/maintenance_rnd{
@@ -93612,19 +90647,6 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/industrial/concrete_bricks,
 /area/liberty/maintenance/undergroundfloor1east)
-"uCF" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/obj/effect/floor_decal/spline/fancy{
-	dir = 8
-	},
-/turf/simulated/floor/industrial/greybricks,
-/area/liberty/bonfire/stronghold)
 "uCJ" = (
 /obj/structure/catwalk,
 /obj/random/structures/low_chance,
@@ -93663,8 +90685,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "uDy" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
@@ -93788,7 +90809,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild1,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "uEU" = (
 /obj/machinery/door/airlock/maintenance_rnd,
 /obj/structure/disposalpipe/segment,
@@ -93819,9 +90840,9 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/undergroundfloor3west)
 "uFr" = (
-/obj/structure/table/woodentable,
-/turf/simulated/floor/tiled/steel/brown_platform,
-/area/liberty/pros/foreman)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating/under,
+/area/liberty/maintenance/undergroundfloor1east)
 "uFw" = (
 /obj/structure/table/standard,
 /obj/machinery/light/small,
@@ -93994,9 +91015,7 @@
 	},
 /obj/effect/floor_decal/spline/fancy,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/bioreactor)
 "uIu" = (
 /obj/structure/railing/grey{
@@ -94295,21 +91314,6 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/asteroid/grass,
 /area/liberty/hallway/side/f2section1)
-"uMe" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood/wild3,
-/area/liberty/command/prime)
 "uMz" = (
 /turf/simulated/shuttle/floor/mining{
 	icon_state = "9,23"
@@ -94514,17 +91518,11 @@
 /turf/simulated/floor/tiled/white/techfloor_grid,
 /area/liberty/security/prisoncells)
 "uPS" = (
-/obj/effect/floor_decal/industrial/loading/white{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/spline/fancy{
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/bioreactor)
 "uPU" = (
 /obj/machinery/atmospherics/unary/vent_pump{
@@ -94554,7 +91552,6 @@
 /area/liberty/maintenance/hideout)
 "uQr" = (
 /obj/machinery/mech_recharger,
-/obj/random/mecha/low_chance,
 /turf/simulated/floor/plating,
 /area/liberty/rnd/robotics)
 "uQB" = (
@@ -95224,15 +92221,15 @@
 /turf/simulated/floor/plating/under,
 /area/liberty/engineering/atmos)
 "var" = (
-/obj/effect/window_lwall_spawn/smartspawn/church,
-/obj/machinery/door/firedoor,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/door/firedoor,
+/obj/effect/window_lwall_spawn/smartspawn,
 /turf/simulated/floor/plating,
-/area/liberty/bonfire/storage)
+/area/colony)
 "vaD" = (
 /obj/item/stack/ore/gold/small,
 /turf/simulated/floor/beach/water/flooded,
@@ -95623,13 +92620,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/fancy_slates,
 /area/liberty/maintenance/undergroundfloor1east)
-"veZ" = (
-/obj/structure/flora/small/trailrocka4,
-/obj/structure/sign/faction/custodians{
-	pixel_x = 32
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/liberty/bonfire/stronghold)
 "vfc" = (
 /obj/machinery/light{
 	dir = 8
@@ -95675,21 +92665,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/spline/fancy{
-	dir = 1
-	},
-/obj/effect/floor_decal/border/carpet/black,
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 1
-	},
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 6
-	},
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 5
-	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/bioreactor)
 "vfu" = (
 /obj/effect/decal/cleanable/rubble,
@@ -95874,6 +92850,9 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8
 	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/liberty/crew_quarters/hydroponics)
 "vib" = (
@@ -95904,13 +92883,6 @@
 	},
 /turf/simulated/floor/wood/wild1,
 /area/liberty/crew_quarters/dorm3)
-"vif" = (
-/obj/effect/floor_decal/wood/tatami,
-/obj/structure/multiz/stairs/enter/bottom{
-	dir = 1
-	},
-/turf/simulated/floor/wood/tatami,
-/area/liberty/bonfire/stronghold)
 "vii" = (
 /obj/machinery/papershredder,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
@@ -96196,7 +93168,10 @@
 /area/liberty/dungeon/outside/campground)
 "vlc" = (
 /obj/machinery/portable_atmospherics/hydroponics,
-/turf/simulated/floor/tiled/steel/techfloor_grid,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/gray_perforated,
 /area/liberty/crew_quarters/hydroponics)
 "vlf" = (
 /obj/effect/decal/cleanable/dirt,
@@ -96220,14 +93195,6 @@
 /obj/effect/decal/cleanable/dirt/snow,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/liberty/maintenance/undergroundfloor2west)
-"vlx" = (
-/obj/machinery/camera/network/custodians,
-/obj/structure/noticeboard/church{
-	pixel_y = 32
-	},
-/obj/structure/closet/oathbound,
-/turf/simulated/floor/tiled/steel/golden,
-/area/liberty/bonfire/office)
 "vly" = (
 /obj/item/stool,
 /obj/effect/decal/cleanable/dirt,
@@ -96380,17 +93347,6 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/liberty/crew_quarters/bar)
-"vnh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
-/area/liberty/bonfire/forge)
 "vnk" = (
 /obj/machinery/atmospherics/pipe/tank/air{
 	dir = 1
@@ -96653,21 +93609,6 @@
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/liberty/crew_quarters/dorm4)
-"vqB" = (
-/obj/structure/closet/crate/hydroponics,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/device/scanner/plant,
-/obj/item/tool/wirecutters,
-/obj/item/plantspray/pests,
-/obj/item/tool/shovel/spade,
-/obj/item/tool/minihoe,
-/obj/item/reagent_containers/glass/fertilizer/rh,
-/obj/item/storage/bag/produce,
-/obj/item/storage/makeshift_grinder,
-/turf/simulated/floor/industrial_pristine/greybricks{
-	dir = 1
-	},
-/area/liberty/bonfire/alchemist)
 "vqC" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 4
@@ -96826,9 +93767,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark/golden,
 /area/liberty/bonfire/vectorrooms)
 "vrQ" = (
 /obj/machinery/holoposter{
@@ -97120,8 +94059,8 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/turf/simulated/floor/plating/under,
+/area/liberty/maintenance/undergroundfloor1east)
 "vuH" = (
 /obj/effect/spider/stickyweb,
 /obj/structure/sign/neon/casino{
@@ -97337,7 +94276,7 @@
 /obj/effect/floor_decal/spline/fancy/corner{
 	dir = 1
 	},
-/turf/simulated/floor/industrial/greybricks,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "vwl" = (
 /obj/structure/table/standard,
@@ -97401,7 +94340,7 @@
 "vwL" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/wall/r_wall,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "vwP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -97533,11 +94472,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/danger,
 /area/liberty/engineering/shield_generator)
-"vyO" = (
-/obj/effect/floor_decal/border/carpet/black,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/bcarpet,
-/area/liberty/bonfire/forge)
 "vyT" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 8;
@@ -97677,15 +94611,10 @@
 /turf/simulated/floor/rock,
 /area/liberty/maintenance/undergroundfloor2east)
 "vBn" = (
-/obj/effect/floor_decal/spline/fancy,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/table/bench/wooden,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "vBx" = (
 /obj/structure/table/bar_special,
@@ -98161,7 +95090,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "vGt" = (
 /obj/structure/multiz/stairs/enter/bottom{
 	dir = 1
@@ -98375,7 +95304,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "vIf" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/item/remains/mouse,
@@ -98389,7 +95318,7 @@
 /turf/simulated/floor/asteroid/grass,
 /area/liberty/maintenance/undergroundfloor1oldgarden)
 "vIk" = (
-/obj/machinery/multistructure/bonfire_part/console,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/liberty/bonfire/bioreactor)
 "vIl" = (
@@ -98597,13 +95526,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/decor_light/wallcandle{
-	pixel_x = -32
-	},
 /obj/effect/floor_decal/spline/fancy{
 	dir = 9
 	},
-/turf/simulated/floor/industrial/greybricks,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "vKo" = (
 /obj/machinery/door/unpowered/simple/wood,
@@ -98786,15 +95712,9 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/obj/effect/floor_decal/spline/fancy{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/spline/plain{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "vNf" = (
 /obj/structure/flora/ausbushes/ywflowers,
@@ -98918,7 +95838,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "vOn" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -98959,18 +95879,12 @@
 /turf/simulated/floor/tiled/dark/cargo,
 /area/liberty/quartermaster/miningdock)
 "vOx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/light,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/wall_mounted/firecloset{
 	pixel_y = -32
 	},
@@ -98981,16 +95895,9 @@
 /obj/effect/floor_decal/industrial/box/red/corners{
 	dir = 4
 	},
-/obj/effect/floor_decal/border/carpet/black,
-/obj/effect/floor_decal/border/carpet/black/corner{
-	dir = 9
-	},
-/obj/effect/floor_decal/border/carpet/black/corner{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "vOF" = (
 /obj/machinery/firealarm{
@@ -98999,8 +95906,8 @@
 	},
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/machinery/camera/network/fontaine,
-/turf/simulated/floor/tiled/steel/brown_perforated,
-/area/liberty/pros/prep)
+/turf/simulated/floor/tiled/dark,
+/area/liberty/maintenance/undergroundfloor1east)
 "vOI" = (
 /obj/structure/sign/levels/stairsdown,
 /turf/simulated/wall/r_wall,
@@ -99044,13 +95951,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/spline/fancy/corner{
-	dir = 8
-	},
-/obj/effect/floor_decal/spline/fancy/corner{
-	dir = 4
-	},
-/turf/simulated/floor/industrial/greybricks,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "vPh" = (
 /obj/machinery/door/window/brigdoor/southright,
@@ -99204,7 +96105,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "vQU" = (
 /obj/structure/bookcase,
 /obj/item/oddity/common/book_omega/closed,
@@ -99328,26 +96229,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/liberty/engineering/atmos)
-"vSF" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/spline/fancy{
-	dir = 1
-	},
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
-/area/liberty/bonfire/office)
 "vSN" = (
 /obj/random/cluster/termite_no_despawn/lower_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -99812,8 +96693,8 @@
 /turf/simulated/floor/rock,
 /area/liberty/maintenance/northcave)
 "vYU" = (
-/obj/effect/window_lwall_spawn/smartspawn/church,
 /obj/machinery/door/firedoor,
+/obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/liberty/bonfire/stronghold)
 "vYW" = (
@@ -100039,9 +96920,7 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 9
 	},
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark/golden,
 /area/liberty/bonfire/vectorrooms)
 "waE" = (
 /obj/effect/decal/cleanable/dirt,
@@ -100448,9 +97327,7 @@
 	dir = 5
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark/golden,
 /area/liberty/bonfire/bioreactor)
 "wfp" = (
 /obj/random/junk/low_chance,
@@ -100520,17 +97397,6 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/liberty/command/bridge)
-"wgg" = (
-/obj/machinery/camera/network/custodians,
-/obj/structure/table/woodentable,
-/obj/machinery/recharger,
-/obj/effect/floor_decal/spline/fancy{
-	dir = 1
-	},
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
-/area/liberty/bonfire/forge)
 "wgl" = (
 /obj/structure/table/gamblingtable,
 /obj/machinery/light/small{
@@ -100630,10 +97496,8 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/maint_merc)
 "wgO" = (
-/obj/structure/table/woodentable,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/simulated/floor/wood,
+/obj/machinery/atmospherics/unary/vent_pump,
+/turf/simulated/wall/r_wall,
 /area/liberty/bonfire/vectorrooms)
 "wgR" = (
 /obj/structure/kitchenspike,
@@ -100733,9 +97597,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/storage)
 "whL" = (
 /obj/structure/disposalpipe/segment,
@@ -100891,14 +97753,10 @@
 /turf/simulated/floor/industrial/fancy_slates,
 /area/liberty/maintenance/undergroundfloor3north)
 "wjr" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/spicebed,
-/turf/simulated/floor/industrial_pristine/greybricks{
-	dir = 1
-	},
-/area/liberty/bonfire/alchemist)
+/obj/machinery/atmospherics/unary/vent_pump,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/liberty/bonfire/vectorrooms)
 "wjH" = (
 /obj/structure/closet/wall_mounted/emcloset/escape_pods{
 	dir = 1;
@@ -101143,11 +98001,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/liberty/command/bridge)
-"wmf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/portable_atmospherics/hydroponics,
-/turf/simulated/floor/tiled/steel/techfloor_grid,
-/area/liberty/crew_quarters/hydroponics)
 "wml" = (
 /obj/structure/grille{
 	desc = "Keeps the ruffians out. Hopefully.";
@@ -101282,26 +98135,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/liberty/security/armory)
-"wof" = (
-/obj/structure/bookcase,
-/obj/item/book/manual/nonfiction/ageofreason,
-/obj/item/book/manual/nonfiction/ethics,
-/obj/item/book/manual/nonfiction/leviathan,
-/obj/item/book/manual/nonfiction/lifewithoutprinciple,
-/obj/item/book/manual/nonfiction/manthereformer,
-/obj/item/book/manual/nonfiction/metaphysics,
-/obj/item/book/manual/nonfiction/thescienceofright,
-/obj/item/book/manual/nonfiction/thetranscendentalist,
-/obj/item/book/manual/nonfiction/suntzu,
-/obj/effect/floor_decal/border/carpet/red,
-/obj/effect/floor_decal/border/carpet/red{
-	dir = 4
-	},
-/obj/effect/floor_decal/border/carpet/red{
-	dir = 6
-	},
-/turf/simulated/floor/carpet,
-/area/liberty/bonfire/stronghold)
 "woh" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 9
@@ -101381,7 +98214,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "woW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -101435,10 +98268,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/liberty/security/armoryshop)
-"wpU" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/wall/church_reinforced,
-/area/liberty/command/prime)
 "wpW" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -101531,30 +98360,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/turret_protected/ai)
-"wrh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/floor_decal/spline/fancy/corner{
-	dir = 8
-	},
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
-/area/liberty/bonfire/forge)
 "wri" = (
 /obj/structure/flora/small/bushb1,
 /turf/simulated/floor/asteroid/grass,
@@ -101812,9 +98617,7 @@
 /obj/effect/floor_decal/industrial/box/red/corners{
 	dir = 4
 	},
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/bioreactor)
 "wtK" = (
 /turf/simulated/floor/tiled/dark/bluecorner,
@@ -101863,13 +98666,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/liberty/maintenance/undergroundfloor3north)
-"wuv" = (
-/obj/effect/floor_decal/spline/fancy{
-	dir = 1
-	},
-/obj/structure/decor_the_twins,
-/turf/simulated/floor/tiled/dark/panels,
-/area/liberty/bonfire/storage)
 "wux" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -101965,15 +98761,9 @@
 /obj/machinery/holoposter{
 	pixel_x = -32
 	},
+/obj/random/mob/spiders/low_chance,
 /turf/simulated/floor/tiled/steel/brown_platform,
-/area/liberty/pros/prep)
-"wvr" = (
-/obj/structure/flora/ausbushes/pointybush,
-/obj/machinery/camera/network/custodians{
-	dir = 8
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/liberty/bonfire/stronghold)
+/area/liberty/maintenance/undergroundfloor1east)
 "wvD" = (
 /obj/structure/flora/tree/snow/snow,
 /turf/simulated/floor/snow,
@@ -102019,14 +98809,8 @@
 "wvT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/spline/plain{
-	dir = 8
-	},
-/obj/effect/floor_decal/spline/fancy{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "wvV" = (
 /obj/effect/decal/cleanable/dirt,
@@ -102156,9 +98940,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/storage)
 "wxW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -102207,7 +98989,7 @@
 /obj/machinery/washing_machine,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "wyu" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -103117,10 +99899,6 @@
 /obj/machinery/camera/network/colony_surface,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/liberty/hallway/surface/section1)
-"wIn" = (
-/obj/random/furniture/pottedplant,
-/turf/simulated/floor/wood,
-/area/liberty/bonfire/vectorrooms)
 "wIr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/chair/office{
@@ -103249,15 +100027,7 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/liberty/engineering/atmos)
 "wJH" = (
-/obj/item/storage/firstaid/ifak{
-	pixel_x = -8
-	},
 /obj/structure/table/rack/shelf,
-/obj/item/storage/firstaid/ifak,
-/obj/item/storage/firstaid/ifak{
-	pixel_x = 8
-	},
-/obj/item/storage/firstaid/ifak,
 /turf/simulated/floor/tiled/steel,
 /area/liberty/engineering/workshop)
 "wJS" = (
@@ -103353,8 +100123,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/turf/simulated/floor/plating/under,
+/area/liberty/maintenance/undergroundfloor1east)
 "wKJ" = (
 /obj/machinery/flasher/portable,
 /obj/machinery/camera/network/security{
@@ -103384,9 +100154,6 @@
 /turf/simulated/floor/rock/alt,
 /area/liberty/maintenance/maint_merc)
 "wLb" = (
-/obj/machinery/door/bonfire{
-	name = "Custodians Stronghold"
-	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -103396,6 +100163,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance_common{
+	req_access = list(12)
+	},
 /turf/simulated/floor/plating,
 /area/liberty/bonfire/stronghold)
 "wLe" = (
@@ -103579,9 +100349,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark/golden,
 /area/liberty/bonfire/vectorrooms)
 "wNd" = (
 /obj/effect/decal/cleanable/dirt,
@@ -103700,26 +100468,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/liberty/maintenance/undergroundfloor3south)
-"wOt" = (
-/obj/structure/closet/wall_mounted/firecloset{
-	pixel_x = 32
-	},
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 4
-	},
-/obj/effect/floor_decal/spline/fancy{
-	dir = 6
-	},
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
-/area/liberty/bonfire/forge)
 "wOv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -103912,15 +100660,10 @@
 	},
 /area/liberty/crew_quarters/hotsprings)
 "wQl" = (
-/obj/effect/floor_decal/spline/fancy{
-	dir = 6
-	},
 /obj/machinery/vending/fitness{
 	shut_up = 1
 	},
-/turf/simulated/floor/industrial_pristine/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "wQp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -103937,15 +100680,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/grey_slates,
 /area/liberty/maintenance/undergroundfloor2east)
-"wQC" = (
-/obj/structure/table/woodentable,
-/obj/machinery/recharger,
-/obj/machinery/camera/network/custodians,
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/liberty/command/prime)
 "wQD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -104161,9 +100895,7 @@
 /obj/structure/table/woodentable,
 /obj/item/paper_bin,
 /obj/item/pen,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/bioreactor)
 "wSZ" = (
 /obj/structure/disposalpipe/segment{
@@ -104238,9 +100970,7 @@
 "wTS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/bioreactor)
 "wTT" = (
 /obj/effect/decal/cleanable/dirt,
@@ -104344,17 +101074,6 @@
 /obj/effect/floor_decal/industrial/danger/corner,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/liberty/pros/shuttle)
-"wVg" = (
-/obj/structure/railing/grey{
-	dir = 8
-	},
-/obj/structure/railing/grey,
-/obj/structure/decor_light/pyre,
-/obj/effect/floor_decal/wood/tatami{
-	dir = 10
-	},
-/turf/simulated/floor/wood/tatami,
-/area/liberty/bonfire/stronghold)
 "wVj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -104608,7 +101327,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "wYU" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 8
@@ -104821,13 +101540,6 @@
 /obj/item/stack/ore/diamond/small,
 /turf/simulated/floor/rock/alt,
 /area/liberty/maintenance/northcave)
-"xbN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/liberty/bonfire/vectorrooms)
 "xbP" = (
 /obj/structure/multiz/stairs/active/bottom{
 	dir = 8
@@ -104866,14 +101578,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/liberty/rnd/research)
-"xch" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/decor_light/wallcandle{
-	pixel_y = -32
-	},
-/obj/machinery/space_heater,
-/turf/simulated/floor/wood,
-/area/liberty/bonfire/vectorrooms)
 "xcr" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -105018,11 +101722,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/liberty/medical/reception)
-"xdM" = (
-/obj/structure/flora/ausbushes/sunnybush,
-/obj/structure/flora/ausbushes/reedbush,
-/turf/simulated/floor/asteroid/grass,
-/area/liberty/bonfire/stronghold)
 "xdX" = (
 /obj/structure/bed/double/padded,
 /obj/random/furniture/bedsheetdouble,
@@ -105183,15 +101882,15 @@
 /turf/simulated/floor/beach/water/ice,
 /area/liberty/outside/pond)
 "xfq" = (
-/obj/structure/closet/secure_closet/personal/trapper,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/structure/closet/random_milsupply,
 /turf/simulated/floor/tiled/white/techfloor_grid,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "xfN" = (
 /obj/machinery/light{
 	dir = 8
@@ -105549,9 +102248,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/storage)
 "xjn" = (
 /obj/random/oddity_guns,
@@ -105662,11 +102359,10 @@
 /turf/simulated/floor/industrial/bricks,
 /area/liberty/maintenance/undergroundfloor1south)
 "xkW" = (
-/obj/machinery/atmospherics/unary/vent_pump,
-/turf/simulated/floor/industrial_pristine/greybricks{
-	dir = 1
-	},
-/area/liberty/bonfire/alchemist)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating/under,
+/area/liberty/bonfire/vectorrooms)
 "xkZ" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -105701,6 +102397,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance_common{
+	req_access = list(12)
 	},
 /turf/simulated/floor/plating,
 /area/liberty/bonfire/stronghold)
@@ -105812,9 +102511,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/storage)
 "xmO" = (
 /obj/structure/bed/chair/sofa/black/right,
@@ -105825,7 +102522,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/carpet/sblucarpet,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "xmS" = (
 /obj/item/stool/padded,
 /obj/effect/decal/cleanable/dirt,
@@ -106142,11 +102839,6 @@
 	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/liberty/medical/genetics_cloning)
-"xqs" = (
-/obj/effect/floor_decal/industrial/hatch,
-/obj/structure/reagent_dispensers/scorch,
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/storage)
 "xqy" = (
 /obj/structure/sign/plaque/dullplaqueimage{
 	pixel_y = 32
@@ -106231,10 +102923,6 @@
 /obj/structure/boulder,
 /turf/simulated/floor/plating/under,
 /area/liberty/maintenance/undergroundfloor3south)
-"xrs" = (
-/obj/effect/floor_decal/industrial/hatch/blue,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/liberty/crew_quarters/hydroponics)
 "xrB" = (
 /obj/structure/bed/chair,
 /obj/effect/decal/cleanable/dirt,
@@ -106275,9 +102963,7 @@
 "xrO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/spline/fancy,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark/golden,
 /area/liberty/bonfire/vectorrooms)
 "xrU" = (
 /obj/effect/decal/cleanable/rubble,
@@ -106423,11 +103109,6 @@
 	},
 /turf/simulated/floor/carpet/purcarpet,
 /area/liberty/crew_quarters/bar)
-"xsU" = (
-/obj/landmark/join/start/trapper,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
 "xta" = (
 /obj/structure/table/rack/shelf,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
@@ -106597,7 +103278,7 @@
 /turf/simulated/mineral,
 /area/liberty/maintenance/undergroundfloor2south)
 "xvd" = (
-/obj/machinery/autolathe/industrial,
+/obj/machinery/autolathe,
 /turf/simulated/floor/tiled/steel,
 /area/liberty/engineering/workshop)
 "xve" = (
@@ -106778,23 +103459,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/liberty/quartermaster/miningdock)
-"xwV" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/table/woodentable,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/obj/machinery/recharger,
-/turf/simulated/floor/wood,
-/area/liberty/bonfire/vectorrooms)
 "xxe" = (
 /turf/simulated/shuttle/wall/escpod{
 	icon_state = "escpodwall16";
@@ -106973,9 +103637,9 @@
 /area/liberty/maintenance/arcade)
 "xzy" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/trashcart,
+/obj/structure/table/rack/shelf,
 /turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "xzD" = (
 /obj/machinery/disposal,
 /turf/unsimulated/mineral,
@@ -107307,18 +103971,20 @@
 /area/liberty/maintenance/undergroundfloor1west)
 "xDl" = (
 /obj/random/furniture/pottedplant,
-/turf/simulated/floor/tiled/dark/golden,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "xDp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 32
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/wood,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/vectorrooms)
 "xDv" = (
 /obj/structure/bed/chair/comfy/blue{
@@ -107463,7 +104129,7 @@
 	pixel_y = 32
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/golden,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/bioreactor)
 "xEE" = (
 /obj/structure/table/rack,
@@ -107484,11 +104150,6 @@
 /area/liberty/maintenance/undergroundfloor1east)
 "xEL" = (
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -107498,15 +104159,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/effect/floor_decal/border/carpet/black,
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 8
-	},
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "xEX" = (
 /turf/simulated/floor/rock,
@@ -107577,16 +104230,10 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/liberty/crew_quarters/barbackroom)
 "xGh" = (
-/obj/structure/table/rack,
 /obj/effect/floor_decal/industrial/warningwhite/full,
-/obj/machinery/button/remote/blast_door{
-	id = "ProspShop";
-	name = "Prospector's shop shutters";
-	pixel_x = -30;
-	req_access = list(78)
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/pros/prep)
+/obj/structure/table/rack/shelf,
+/turf/simulated/floor/plating/under,
+/area/liberty/maintenance/undergroundfloor1east)
 "xGj" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/generic,
@@ -107737,10 +104384,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/quartermaster/fightclub)
-"xIn" = (
-/obj/structure/decor_light/pyre,
-/turf/simulated/floor/tiled/dark/panels,
-/area/liberty/bonfire/storage)
 "xIo" = (
 /obj/machinery/optable,
 /obj/effect/decal/cleanable/blood,
@@ -107828,7 +104471,7 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 4
 	},
-/turf/simulated/floor/industrial/greybricks,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "xJm" = (
 /obj/effect/decal/cleanable/dirt,
@@ -107981,8 +104624,10 @@
 	dir = 8;
 	pixel_x = 32
 	},
-/turf/simulated/floor/wood/wild3,
-/area/liberty/pros/foreman)
+/obj/effect/decal/cleanable/dirt,
+/obj/random/firstaid/low_chance,
+/turf/simulated/floor/tiled/dark,
+/area/liberty/maintenance/undergroundfloor1east)
 "xLa" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -108233,7 +104878,7 @@
 /area/liberty/quartermaster/office)
 "xNP" = (
 /obj/effect/floor_decal/industrial/box/white,
-/turf/simulated/floor/tiled/dark/golden,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/bioreactor)
 "xNQ" = (
 /obj/structure/sign/warning/nosmoking/small,
@@ -109119,18 +105764,13 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 1
-	},
-/obj/effect/floor_decal/border/carpet/black,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/stronghold)
 "xXJ" = (
 /obj/structure/disposalpipe/segment{
@@ -109141,17 +105781,10 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/undergroundfloor3east)
 "xXO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 24
-	},
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/vectorrooms)
 "xXX" = (
 /obj/structure/railing{
@@ -109167,8 +105800,8 @@
 /turf/simulated/floor/plating/under,
 /area/liberty/engineering/engine_room)
 "xYl" = (
-/obj/machinery/multistructure/bonfire_part/port,
 /obj/effect/floor_decal/industrial/outline,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/liberty/bonfire/bioreactor)
 "xYp" = (
@@ -109444,7 +106077,7 @@
 /obj/item/stack/cable_coil/white,
 /obj/structure/table/steel_reinforced,
 /turf/simulated/floor/tiled/steel/brown_perforated,
-/area/liberty/pros/prep)
+/area/liberty/maintenance/undergroundfloor1east)
 "yaQ" = (
 /obj/structure/grille{
 	desc = "Keeps the ruffians out. Hopefully.";
@@ -109480,8 +106113,8 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/bonfire{
-	name = "Forge Room"
+/obj/machinery/door/airlock/maintenance_common{
+	req_access = list(12)
 	},
 /turf/simulated/floor/plating,
 /area/liberty/bonfire/bioreactor)
@@ -109591,18 +106224,6 @@
 /obj/structure/railing,
 /turf/simulated/floor/tiled/dark/golden,
 /area/liberty/crew_quarters/skyyard)
-"ycD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks{
-	dir = 1
-	},
-/area/liberty/bonfire/stronghold)
 "ycO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/industrial/arrows/white{
@@ -109615,14 +106236,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/bricks,
 /area/liberty/maintenance/undergroundfloor2south)
-"ycT" = (
-/obj/structure/decor_perfect_pillar,
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/bcarpet,
-/area/liberty/bonfire/forge)
 "ycU" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/carpet/blucarpet,
@@ -109653,15 +106266,6 @@
 	},
 /turf/simulated/floor/rock/manmade/road,
 /area/liberty/security/maingate_outside)
-"yde" = (
-/obj/structure/table/woodentable,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/effect/floor_decal/border/carpet/red{
-	dir = 1
-	},
-/turf/simulated/floor/carpet,
-/area/liberty/bonfire/stronghold)
 "ydf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/overlay/water/top,
@@ -109919,12 +106523,9 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/undergroundfloor2north)
 "yfY" = (
-/obj/structure/bed/chair/wood,
-/obj/effect/floor_decal/border/carpet/red{
-	dir = 1
-	},
-/obj/landmark/join/start/oathbound,
-/turf/simulated/floor/carpet,
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/vectorrooms)
 "yge" = (
 /obj/structure/disposalpipe/segment,
@@ -110053,7 +106654,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/greybricks,
+/turf/simulated/floor/tiled/dark/golden,
 /area/liberty/bonfire/bioreactor)
 "yhc" = (
 /obj/structure/flora/snowgrass/rockandgrass,
@@ -110157,14 +106758,10 @@
 /turf/simulated/wall/r_wall,
 /area/liberty/security/tactical)
 "yif" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
-	},
-/obj/effect/floor_decal/spline/fancy{
-	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -110172,21 +106769,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/obj/effect/floor_decal/spline/fancy/corner{
-	dir = 1
-	},
 /obj/machinery/hologram/holopad,
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 8
-	},
-/obj/effect/floor_decal/border/carpet/black,
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 10
-	},
-/obj/effect/floor_decal/border/carpet/black/corner{
-	dir = 5
-	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/tiled/dark,
 /area/liberty/bonfire/bioreactor)
 "yij" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
@@ -110389,16 +106973,17 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/maint_merc)
 "yjX" = (
-/obj/structure/closet/secure_closet/reinforced/field_shepherd,
-/turf/simulated/floor/tiled/steel/brown_platform,
-/area/liberty/pros/foreman)
-"yko" = (
-/obj/effect/floor_decal/spline/fancy{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/storage)
+/obj/item/reagent_containers/glass/bucket{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/liberty/maintenance/undergroundfloor1east)
+"yko" = (
+/obj/landmark/join/start/oathbound,
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/liberty/pros/shuttle)
 "ykx" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -110453,11 +107038,10 @@
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/liberty/rnd/robotics)
 "ykU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/liberty/bonfire/vectorrooms)
 "ykV" = (
@@ -110512,10 +107096,6 @@
 /obj/machinery/camera/network/mining,
 /turf/simulated/floor/tiled/white/monofloor,
 /area/shuttle/rocinante_shuttle_area)
-"ylx" = (
-/mob/living/carbon/superior_animal/lord_foog,
-/turf/simulated/floor/carpet/bcarpet,
-/area/liberty/command/prime)
 "ylB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -164245,7 +160825,7 @@ dgr
 dgr
 bXb
 oNU
-cwg
+uQr
 uzo
 uQr
 pHm
@@ -169273,8 +165853,8 @@ pxd
 pxd
 pxd
 gWs
-sbQ
-sbQ
+gWs
+gWs
 woy
 bzF
 ujI
@@ -178149,7 +174729,7 @@ oMc
 kJd
 gyo
 mPt
-arE
+rjk
 rjk
 rjk
 ljS
@@ -193344,7 +189924,7 @@ upq
 upq
 upq
 upq
-upq
+rTA
 mXG
 aPB
 oQS
@@ -193546,7 +190126,7 @@ upq
 upq
 upq
 upq
-upq
+ccQ
 mXG
 rOo
 omv
@@ -193748,7 +190328,7 @@ upq
 upq
 upq
 upq
-upq
+ffy
 bRK
 odm
 omv
@@ -193950,7 +190530,7 @@ upq
 upq
 upq
 upq
-upq
+yko
 lYH
 aPB
 rQC
@@ -194150,9 +190730,9 @@ upq
 upq
 upq
 upq
-upq
-upq
-upq
+qLo
+tBR
+fGF
 mXG
 aPB
 pFr
@@ -206237,13 +202817,13 @@ sPV
 sPV
 vYU
 qtp
-ejt
+sPV
 sPV
 mRu
 lfX
 oPQ
 sPV
-ejt
+sPV
 cqx
 cqx
 sPV
@@ -206441,14 +203021,14 @@ haP
 vMZ
 nnD
 cWA
-koY
+kGI
 qjJ
 tZw
 gqC
 pAO
-pAO
+lSv
 aMj
-cwa
+mfH
 sPV
 fFw
 rgr
@@ -206640,16 +203220,16 @@ wfd
 frp
 fbw
 kGI
-tGV
-fDZ
-fDZ
-fDZ
+mVB
+mfH
+mVB
+mVB
 jhX
-fDZ
-fDZ
-fDZ
-wVg
-ycD
+mfH
+mVB
+mVB
+mfH
+tZw
 kSm
 vYU
 luq
@@ -206841,18 +203421,18 @@ jZR
 aXi
 ttZ
 pSb
-qWl
-mAo
-rPk
+mfH
 mVB
 mVB
-miP
+mfH
+mfH
+jhX
+mfH
 mVB
 mVB
-gRW
-jzX
-pUW
-cgx
+mfH
+mVB
+nWX
 sPV
 luq
 rgr
@@ -207043,17 +203623,17 @@ qbD
 pTB
 ocL
 bXX
-ugU
-jMN
-prG
-rPk
+mfH
 mVB
-miP
 mVB
-gRW
-tIX
-jzX
-pUW
+mVB
+mVB
+jhX
+mfH
+mVB
+mVB
+mfH
+mVB
 nWX
 vYU
 jbn
@@ -207232,29 +203812,29 @@ sPV
 jvb
 cxb
 ufE
-nrl
+ptb
 pgl
-xIn
-lpM
+mrD
+ttZ
 bne
-jqZ
-jqZ
-kIu
-iEn
-bYC
+hEk
+hEk
+vIk
+cuz
+hEk
 uIr
 ttZ
 hRx
 ibr
-iYl
 gVR
 gVR
-gxv
+gVR
+gVR
 jdn
-hZB
-tIX
-tIX
-jzX
+mVB
+mVB
+mVB
+mfH
 llh
 scx
 sPV
@@ -207434,30 +204014,30 @@ sPV
 jvb
 kcb
 cxm
-nrl
+ptb
 tcU
 nnh
 ttZ
-qPJ
-jqZ
-jqZ
+bne
+hEk
+hEk
 vIk
-pQB
-bYC
+cuz
+hEk
 rdY
 lpM
 rtw
-jeJ
-uzA
-prG
-iKY
-cXu
-cXu
-cXu
-sdm
-tIX
-cFH
-pUW
+mVB
+mfH
+mVB
+mVB
+mVB
+mVB
+mVB
+mVB
+mVB
+mfH
+mVB
 nWX
 vYU
 ojp
@@ -207638,28 +204218,28 @@ sre
 nrl
 lQo
 kUp
-yko
+mrD
 ttZ
 dDR
 hEk
-dTC
+hEk
 xYl
 cuz
-bYC
+hEk
 aKZ
 ttZ
 eLt
-jeJ
-uzA
-iKY
-cXu
-cXu
-cXu
-cXu
-cXu
-sdm
-vif
-dMJ
+mVB
+mfH
+mfH
+mVB
+mVB
+mfH
+mVB
+mVB
+mfH
+mVB
+mVB
 vBn
 sPV
 cTd
@@ -207852,15 +204432,15 @@ qof
 lpM
 eTS
 tcC
-mNJ
-oOl
-oOl
-boT
-deQ
-sXH
-oOl
-oOl
-qty
+mfH
+mVB
+mVB
+mVB
+mfH
+mVB
+mVB
+mfH
+mVB
 uhK
 hCQ
 vYU
@@ -208038,29 +204618,29 @@ bcY
 cEA
 sPV
 jvb
-bmN
+nrl
 nrl
 haR
 nrl
-hEt
+nrl
 ttZ
 bhp
-rLC
+cuz
 nBc
 nVD
-bYC
-bYC
+hEk
+hEk
 wtE
 ttZ
 pdE
 aOf
 chL
+wvT
+wvT
+wvT
 fZK
-bAQ
 wvT
-bAQ
 wvT
-bAQ
 fZK
 fyT
 uqB
@@ -208240,15 +204820,15 @@ saN
 aRj
 sPV
 jvb
-qsu
+nrl
 pGV
 hQx
 xjC
-wuv
-lpM
-ody
-lSv
-ody
+nrl
+ttZ
+hEk
+hEk
+hEk
 gMd
 wTS
 gix
@@ -208257,12 +204837,12 @@ ttZ
 sPV
 xlm
 sPV
-sPV
-vYU
-vYU
-vYU
-vYU
-vYU
+mVB
+mVB
+mVB
+mfH
+mVB
+mVB
 sPV
 sPV
 cBR
@@ -208442,15 +205022,15 @@ saN
 iLm
 sPV
 jvb
-kiq
+nrl
 nrl
 jAM
 nde
-fly
+nrl
 ttZ
 xEB
-baG
-ody
+hEk
+hEk
 hAG
 gch
 gWh
@@ -208459,16 +205039,16 @@ ttZ
 kls
 azE
 sPV
-sPV
+mVB
 mfH
-dBc
-qGw
-bAb
-xdM
+mfH
+mVB
+mfH
+mfH
 sPV
 mUK
-kDL
-gSX
+azE
+mfH
 sPV
 qSP
 hJI
@@ -208651,7 +205231,7 @@ jvb
 jvb
 ttZ
 xNP
-rRu
+hEk
 kYa
 vfq
 aZe
@@ -208659,18 +205239,18 @@ sNx
 wSR
 ttZ
 dVX
-spS
+azE
 sPV
-sPV
-dWg
-adx
-wvr
-veZ
-rmT
+hkb
+mVB
+mVB
+mVB
+mfH
+hkb
 sPV
 lWp
-sBo
-hIY
+azE
+mfH
 sPV
 dTX
 hJI
@@ -208849,19 +205429,19 @@ jvb
 nGq
 nGq
 tRZ
-xqs
-xqs
+nGq
+nGq
 ttZ
 ttZ
-lpM
-lpM
+adx
+ecH
 siG
 yaY
-lpM
+ecH
 ttZ
 ttZ
 jPY
-spS
+azE
 sPV
 sPV
 sPV
@@ -209061,7 +205641,7 @@ jQK
 xEL
 gAY
 eGJ
-uCF
+olE
 aMW
 flI
 sPV
@@ -209072,9 +205652,9 @@ usE
 usE
 usE
 sPV
-qQv
+eHU
 kwY
-lRn
+fZK
 pui
 chi
 cIh
@@ -209257,13 +205837,13 @@ nxr
 jsd
 qOU
 lsd
-lYc
+czH
 kin
 pBd
 hSS
 rtE
-nZG
-jwO
+swr
+rbM
 bhy
 vOx
 sPV
@@ -209274,9 +205854,9 @@ jrv
 eSc
 usE
 sPV
-yde
-iFk
-efZ
+mfH
+mfH
+mfH
 sPV
 hJF
 jNf
@@ -209457,14 +206037,14 @@ xmF
 cHO
 rWJ
 sYa
-blG
+jvb
 jot
 vwj
 bVH
-nMJ
-jFM
+mfH
+mfH
 izg
-kUb
+rDK
 bgs
 iws
 gYE
@@ -209476,9 +206056,9 @@ eSc
 eSc
 usE
 sPV
-mrp
-iFk
-pEg
+mfH
+mfH
+mfH
 sPV
 rZG
 dBj
@@ -209662,14 +206242,14 @@ dgW
 jvb
 jvb
 exD
-dzz
-qfI
-sGB
-ciF
-dzz
-dzz
+sPV
+sPV
+sPV
+sPV
+sPV
+sPV
 iIm
-gkK
+gYE
 sPV
 hFu
 usE
@@ -209678,9 +206258,9 @@ eSc
 eSc
 usE
 sPV
-rZo
+mfH
 hkb
-wof
+mfH
 sPV
 cTd
 cIq
@@ -209859,19 +206439,19 @@ jvb
 unb
 unb
 qRk
-frm
-frm
+unb
+unb
 jvb
 bjh
 pfw
-dzz
-qzb
-wrh
-nGr
-jfm
-dzz
+sPV
+omv
+omv
+omv
+omv
+sPV
 iIm
-gkK
+gYE
 sPV
 hFu
 usE
@@ -210066,14 +206646,14 @@ jvb
 jvb
 jvb
 jvb
-dzz
-iNj
-ahe
-jLC
-ePf
-dzz
+sPV
+omv
+omv
+omv
+omv
+sPV
 iIm
-gkK
+gYE
 sPV
 usE
 usE
@@ -210259,26 +206839,26 @@ veD
 saN
 sMP
 sPV
-mZb
-ccl
-qkz
-kai
-ccl
-tUJ
-tUJ
-tUJ
-tUJ
-qVN
-iIu
-bio
-iOX
-tli
-dzz
+aOV
+aOV
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+sPV
 cjQ
 lKi
-ejt
+sPV
 usE
-bUR
+urU
 cIU
 cIU
 cIU
@@ -210461,23 +207041,23 @@ veD
 saN
 aRj
 sPV
-mZb
-ecH
-pvP
-cby
-ccQ
-tUJ
-pCA
-nJD
-tUJ
-tUJ
-wgg
-vnh
-oRX
-aXH
-dzz
+omv
+aOV
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+sPV
 iIm
-gkK
+gYE
 sPV
 usE
 kwX
@@ -210663,23 +207243,23 @@ veD
 saN
 rgr
 sPV
-mZb
-vlx
-iyZ
-gSB
-ffy
-tUJ
-iNZ
-mWx
-ylx
-tUJ
-nsT
-eBu
-jLC
-phg
-dzz
+omv
+aOV
+aOV
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+sPV
 iiJ
-eww
+xXE
 sPV
 usE
 eqK
@@ -210688,7 +207268,7 @@ cIU
 sSV
 vlc
 vlc
-wmf
+sSV
 vlc
 vlc
 ndW
@@ -210865,21 +207445,21 @@ veD
 saN
 rgr
 sPV
-mZb
-glE
-fSn
-rSM
-nFc
-tUJ
-qjo
-kzW
-mWx
-tUJ
-dDi
-ycT
-jkr
-qBu
-dzz
+omv
+omv
+aOV
+aOV
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+sPV
 iIm
 xXE
 sPV
@@ -210887,12 +207467,12 @@ usE
 cBT
 vrM
 urU
-tET
-xrs
-xrs
-xrs
-xrs
-xrs
+urU
+urU
+urU
+urU
+urU
+urU
 uec
 tlx
 aqW
@@ -211067,34 +207647,34 @@ veD
 saN
 rgr
 sPV
-mZb
-ecH
-fSn
-rTA
+omv
+omv
+omv
 aOV
-tUJ
-wQC
-tBR
-ans
-wpU
-rDK
-kJs
-vyO
-bxs
-dzz
+aOV
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+sPV
 bQe
 mdI
-ejt
+sPV
 usE
 rGP
 vrM
 urU
-tET
-xrs
-xrs
-xrs
-xrs
-xrs
+vlc
+vlc
+vlc
+vlc
+vlc
+vlc
 iqJ
 jem
 vbU
@@ -211269,34 +207849,34 @@ veD
 saN
 rgr
 sPV
-mZb
-ccl
-vSF
-muI
-lAn
-tUJ
-dep
-czH
-nZj
-tUJ
-gnE
-beQ
-uzU
-qBu
-dzz
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+sPV
 iIm
-gkK
+gYE
 sPV
 usE
 mzt
 vrM
 cIU
 dhH
-xrs
-xrs
-cBk
-xrs
-xrs
+urU
+urU
+urU
+urU
+urU
 pEW
 kuO
 xEG
@@ -211471,34 +208051,34 @@ veD
 saN
 iLm
 sPV
-mZb
-mZb
+sPV
+sPV
 mnp
-mZb
-mZb
-tUJ
-kOY
-uMe
-kQf
-tUJ
-dwr
-anb
-wOt
-spK
-dzz
+sPV
+sPV
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+sPV
 iIm
-gkK
+gYE
 sPV
 usE
 iyk
 vrM
 cIU
-tET
-xrs
-xrs
-xrs
-xrs
-xrs
+vlc
+vlc
+vlc
+vlc
+vlc
+vlc
 iqJ
 uQB
 ubL
@@ -211675,33 +208255,33 @@ aRj
 sPV
 sPV
 qjr
-rnQ
-nkE
+xXE
+mfH
 sPV
-tUJ
-tUJ
-flu
-tUJ
-tUJ
-dzz
-dzz
-dzz
-dzz
-dzz
+sPV
+sPV
+sPV
+sPV
+sPV
+sPV
+sPV
+sPV
+sPV
+sPV
 iIm
-gkK
+gYE
 sPV
 usE
 gbL
 vrM
 cIU
-tET
-xrs
-xrs
-xrs
-xrs
-xrs
-iqJ
+urU
+urU
+urU
+urU
+urU
+urU
+nMJ
 bAn
 pJI
 pWa
@@ -211874,21 +208454,21 @@ amm
 veD
 saN
 rgr
-ryJ
-ejt
+pPu
+sPV
 eHU
 cxs
 cGa
-uCF
+olE
 cGa
-cGa
+cwg
 vOZ
 cGa
 gEJ
 cGa
 cGa
-cGa
-cGa
+eGJ
+eGJ
 olE
 iBu
 spW
@@ -211900,7 +208480,7 @@ cIU
 sSV
 iWJ
 iWJ
-wmf
+sSV
 iWJ
 vlc
 vhK
@@ -212088,9 +208668,9 @@ jSW
 lYc
 hko
 lYc
-lYc
-sFJ
-lYc
+kbo
+hSS
+swr
 rbM
 gcJ
 fGB
@@ -212279,20 +208859,20 @@ veD
 ngd
 rgr
 pPu
-ejt
+sPV
 xJj
 fZM
-kUb
+rDK
 bgs
-kUb
-ptb
-kyn
-kUb
+mfH
+mfH
+xXE
+mfH
 isS
+mfH
 kUb
-kUb
-aNZ
-kUb
+mfH
+mfH
 bgs
 nxn
 oTn
@@ -212486,19 +209066,19 @@ kOu
 iDQ
 xDl
 sPV
-mBk
-mBk
-lXv
+sPV
+sPV
+sPV
+sPV
+gMI
+gMI
 hJR
-mBk
-mBk
-hJR
-iYN
-mBk
-mBk
+gMI
+gMI
+gMI
 nag
 txN
-mBk
+gMI
 usE
 bII
 bII
@@ -212685,23 +209265,23 @@ iLm
 sPV
 sPV
 sPV
-oTj
 sPV
-mBk
-mBk
-ftV
-swr
-oDY
-qIW
+sPV
+sPV
+omv
+omv
+omv
+omv
+gMI
 dxd
 bIN
-aBP
-pqg
-ibE
+rhK
+gMI
+gMI
 idM
 vrN
-mBk
-mBk
+gMI
+gMI
 bhK
 diE
 bhK
@@ -212885,25 +209465,25 @@ veD
 ngd
 rgr
 sPV
-sPV
-sPV
-sPV
-sPV
-mBk
-fvv
-pnY
-tYM
-tkS
-nAI
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+gMI
 rOO
 tgI
-qMJ
-mBk
-mBk
+jKQ
+gMI
+gMI
 sFa
 cEu
 tpI
-mBk
+gMI
 bhK
 bhK
 dql
@@ -213091,15 +209671,15 @@ sPV
 sPV
 sPV
 sPV
-mBk
-xwV
-tgI
-nxo
-mRT
-mRT
+gMI
+gMI
+gMI
+gMI
+gMI
+gMI
 mCg
-ndy
-dyF
+bIN
+jKQ
 utS
 waD
 hPf
@@ -213289,19 +209869,19 @@ gXB
 vwq
 vLZ
 sPV
-mBk
-mBk
-kGU
-mBk
-mBk
+qPJ
+jKQ
+jKQ
+jKQ
+gMI
 psQ
 ndy
 yfY
+yfY
 mRT
-mRT
-cAx
 ndy
-lOD
+tgI
+jKQ
 utS
 uCn
 nzU
@@ -213491,19 +210071,19 @@ xJo
 ngd
 rgr
 sPV
-mBk
-fyr
-bmh
-giu
+jKQ
+jKQ
+jKQ
+jKQ
 brb
-uoZ
-ndy
-mRj
-fEg
-etC
-eVn
-ndy
-nxy
+rhK
+jKQ
+jKQ
+jKQ
+rhK
+rhK
+tHU
+rhK
 utS
 djS
 wNa
@@ -213695,17 +210275,17 @@ rgr
 sPV
 alX
 qIf
-tHU
-oUu
-mBk
-qYZ
-tgI
-bgt
-rzh
-mRT
-kIW
-ndy
-ejA
+jKQ
+jKQ
+gMI
+rhK
+rhK
+rhK
+jKQ
+jKQ
+rhK
+qgm
+jKQ
 utS
 itP
 gak
@@ -213895,25 +210475,25 @@ veD
 ngd
 rgr
 sPV
-mBk
-aFA
-qLo
-rzm
-mBk
-esw
-iMY
+gMI
+gMI
+mCg
+jKQ
+gMI
+jKQ
+jKQ
 rhK
-qer
-iaz
-cdM
-ndy
-xch
-mBk
-mBk
+rhK
+rhK
+jKQ
+tHU
+jKQ
+gMI
+gMI
 sFa
 hyQ
 mEA
-mBk
+gMI
 bhK
 bhK
 ddD
@@ -214097,12 +210677,12 @@ veD
 ngd
 rgr
 sPV
+uzU
 mBk
-mBk
-mBk
-sAi
-mBk
-mBk
+jKQ
+jKQ
+gMI
+anb
 kHV
 epz
 xDp
@@ -214114,8 +210694,8 @@ rOb
 gMI
 jrJ
 xrO
-mBk
-mBk
+gMI
+gMI
 bhK
 bhK
 ddD
@@ -214299,25 +210879,25 @@ tYG
 ngd
 sMP
 sPV
-mBk
-cJC
-kbT
-lDf
-olM
-olM
-olM
+gMI
+gMI
+mCg
+jKQ
+gMI
+nJD
+kHV
 dPI
-olM
-olM
-mBk
-mBk
 qgm
-mBk
-mBk
+olM
+jKQ
+rhK
+qgm
+jKQ
+gMI
 pHq
 dax
-mBk
-mBk
+gMI
+gMI
 bhK
 aWp
 jux
@@ -214501,25 +211081,25 @@ tYG
 ngd
 aRj
 sPV
+jeJ
 mBk
-mBk
-mBk
-rwB
-olM
-vqB
-jrg
-rnK
+jKQ
+jKQ
+gMI
+gMI
+gMI
+gMI
 reg
-olM
+gMI
 wgO
-osL
-jxp
-wIn
-mBk
-lgI
-tzL
-mBk
-mBk
+gMI
+reg
+gMI
+gMI
+fXX
+uby
+gMI
+gMI
 bhK
 fcg
 jux
@@ -214703,21 +211283,21 @@ wHR
 ngd
 rgr
 sPV
-mBk
-cJC
-kbT
+gMI
+gMI
+mCg
 jKQ
-olM
+gMI
 wjr
 kLD
-osi
+pRn
 mod
-olM
-pGz
+gMI
+wjr
 pRn
 lXR
 eux
-mBk
+gMI
 xCo
 keV
 keV
@@ -214905,21 +211485,21 @@ veD
 ngd
 rgr
 sPV
+jeJ
 mBk
-mBk
-mBk
-mBk
-olM
+jKQ
+jKQ
+gMI
 khU
 xkW
 kyA
 fnR
-olM
-eGI
-cdM
+gMI
+khU
+kyA
 ykU
-xbN
-mBk
+cdM
+gMI
 wSg
 dkg
 keV
@@ -215106,22 +211686,22 @@ jux
 veD
 ngd
 aRj
-mkt
-mkt
-mkt
-mkt
-mkt
-olM
+fCa
+fCa
+fCa
+fCa
+fCa
+gMI
 bRd
-hmd
-qOI
+cdM
+bRd
 cSK
-olM
+gMI
 tJm
 nef
-qSH
+cdM
 pKR
-mBk
+gMI
 xCo
 keV
 keV
@@ -215308,26 +211888,26 @@ jux
 veD
 ngd
 rgr
-dOW
+cbw
 xGh
 iJK
 aSy
-mkt
-olM
-olM
-olM
-olM
-olM
-olM
-mBk
-mBk
-mBk
-mBk
-mBk
+fCa
+gMI
+gMI
+gMI
+gMI
+gMI
+gMI
+gMI
+gMI
+gMI
+gMI
+gMI
 fXX
-kbo
-mkt
-mkt
+uby
+fCa
+fCa
 bhK
 bhK
 jux
@@ -215510,26 +212090,26 @@ jux
 veD
 ngd
 rgr
-dOW
-bcu
-bcu
+cbw
+ahe
+ahe
 bNZ
 mkt
-mkt
-mkt
-mkt
-mkt
-mkt
-mkt
-mkt
-mkt
-mkt
-mkt
-mkt
+fCa
+fCa
+fCa
+fCa
+fCa
+fCa
+fCa
+fCa
+fCa
+fCa
+fCa
 qgH
 ozK
-mkt
-mkt
+fCa
+fCa
 bhK
 aWp
 jux
@@ -215714,19 +212294,19 @@ upj
 gTX
 qfG
 czr
-bcu
+ahe
 gTu
 jVJ
-mkt
+fCa
 mUI
 oxv
 tUu
 mti
-sTC
+oxv
 rYK
 lOH
 gDw
-mkt
+fCa
 xmO
 txd
 guU
@@ -215914,21 +212494,21 @@ jux
 veD
 ngd
 rgr
-dOW
+cbw
 kpg
 kPC
 uzy
 lgP
 cTn
 jLi
-oxv
-cAq
+sTC
+uFr
 htn
 vQN
-cAq
 lOH
+uFr
 uzb
-mkt
+fCa
 nGC
 txd
 mWb
@@ -216116,21 +212696,21 @@ jux
 veD
 ngd
 rgr
-mkt
-rnw
-rnw
+fCa
+cbw
+cbw
 kMh
 cTn
 cTn
 xfq
 oxv
-cAq
+uFr
 sUr
 dAH
-cAq
+uFr
 lOH
 fZN
-mkt
+fCa
 dDN
 txd
 mWb
@@ -216330,9 +212910,9 @@ lov
 ifL
 wKC
 vuG
-qIx
-mkt
-mkt
+uFr
+fCa
+fCa
 ogn
 txd
 guU
@@ -216539,7 +213119,7 @@ uEO
 dHj
 mYG
 nrK
-mkt
+fCa
 oLa
 bhK
 ddD
@@ -216722,29 +213302,29 @@ jux
 iHF
 fcp
 oae
-mkt
+fCa
 ktR
 cBv
 ccz
-bcu
+rSM
 sVE
-mkt
-mkt
-mkt
+fCa
+fCa
+fCa
 kqU
 bml
 qzX
-mkt
-mkt
+fCa
+fCa
 gii
 gii
 jPH
 gii
 mSu
-mkt
-mkt
-mkt
-mkt
+fCa
+fCa
+fCa
+fCa
 dwp
 byg
 rQC
@@ -216924,21 +213504,21 @@ jux
 pjE
 hxS
 fSy
-mkt
+fCa
 vOF
 ruJ
 ccz
 bcu
 vIe
-mkt
+fCa
 gAv
 sAh
 swM
 daG
 fno
 jAR
-mkt
-mkt
+fCa
+fCa
 scm
 lDv
 gii
@@ -216946,7 +213526,7 @@ lDv
 enI
 tOI
 wyq
-mkt
+fCa
 dwp
 dwp
 rQC
@@ -217126,29 +213706,29 @@ jux
 jux
 uCb
 jux
-cWY
-cWY
+fCa
+fCa
 cbw
 tDf
 cbw
-cWY
-mkt
+fCa
+fCa
 jdr
-xsU
+lOH
 fAD
 sNu
 bcu
 bcu
 bcu
-mkt
-mkt
+fCa
+fCa
 dzM
 uze
 cYm
-mkt
+fCa
 aoh
 woU
-mkt
+fCa
 dwp
 dwp
 iSy
@@ -217328,29 +213908,29 @@ bps
 aqt
 mLR
 bps
-cWY
+fCa
 bSb
-jGR
+oxv
 gJo
 iRG
 uaR
-mkt
+fCa
 aYe
-xsU
+lOH
 hSd
-msb
-kme
 sra
-cAq
+sra
+sra
+lOH
 uxT
-mkt
-mkt
-mkt
-mkt
-mkt
-mkt
-mkt
-mkt
+fCa
+fCa
+fCa
+fCa
+fCa
+fCa
+fCa
+fCa
 dwp
 dwp
 rQC
@@ -217530,26 +214110,26 @@ bps
 aqt
 mLR
 bps
-cWY
+fCa
 cjU
 tAf
 dpc
 bHE
 uiZ
-rnw
+cbw
 gGX
-xsU
+lOH
 hSd
 sra
 sra
-msb
-cAq
-cAq
+sra
+lOH
+lOH
 eiX
 wvp
 sNN
 eJU
-mkt
+fCa
 uKZ
 uKZ
 dwp
@@ -217732,14 +214312,14 @@ bps
 aqt
 mLR
 bps
-cWY
+fCa
 bOf
 kQw
 pvZ
 iHi
-jGR
-rnw
-fGF
+uFr
+cbw
+pYX
 cAq
 wYN
 bcu
@@ -217747,11 +214327,11 @@ bcu
 nHe
 bcu
 cOF
-mkt
+fCa
 unl
-cNZ
+unl
 yaL
-mkt
+fCa
 uKZ
 uKZ
 dwp
@@ -217934,26 +214514,26 @@ bps
 oSz
 mLR
 bps
-cWY
+fCa
 sKA
 rCM
 gWZ
 hgD
-jGR
-rnw
+lOH
+cbw
 pYX
 sTC
 hSd
+qkz
 xzy
-xzy
-cAq
-aJD
+glE
+pYX
 lxR
-mkt
-hBY
+fCa
 aLS
-mkt
-mkt
+aLS
+fCa
+fCa
 uKZ
 uKZ
 dwp
@@ -218136,25 +214716,25 @@ iGH
 uXu
 ijg
 bps
-cWY
+fCa
 ixA
 prk
 teT
 mOZ
 opO
-mkt
-mkt
-sTC
+fCa
+fCa
+srP
 qHq
-mkt
-mvL
-hic
-mvL
-mkt
-mkt
-mkt
-mkt
-mkt
+fCa
+fCa
+fCa
+fCa
+fCa
+fCa
+fCa
+fCa
+fCa
 uKZ
 uKZ
 uKZ
@@ -218340,18 +214920,18 @@ aqt
 bps
 cWY
 yjX
-srP
+lOH
 uFr
 xKQ
 epd
-mkt
-lkc
-cAq
-aXn
+fCa
+dqg
+lOH
+iHi
 iQl
-mkt
-mkt
-mkt
+fCa
+fCa
+fCa
 uKZ
 uKZ
 uKZ
@@ -218540,18 +215120,18 @@ bps
 aqt
 aqt
 bps
-cWY
-cWY
-cWY
-cWY
-cWY
-cWY
-mkt
-keg
-cAq
-aXn
+fCa
+fCa
+fCa
+fCa
+fCa
+fCa
+fCa
+dqg
+lOH
+iHi
 aGI
-orL
+bps
 rQH
 dMf
 dMf
@@ -218748,12 +215328,12 @@ omv
 omv
 omv
 omv
-mkt
+fCa
 dqg
-cAq
-aXn
+lOH
+iHi
 pFF
-mkt
+fCa
 omv
 omv
 omv
@@ -218950,12 +215530,12 @@ omv
 omv
 omv
 omv
-mkt
-mkt
-mkt
-mkt
-mkt
-mkt
+fCa
+fCa
+fCa
+fCa
+fCa
+fCa
 omv
 omv
 omv


### PR DESCRIPTION
## Changelog
1. Removed the Custodians from the colony map, replaced with empty storage rooms and unfurnished space. 
2. Removed Fontaine from the colony map, replaced with an easily habitable maints base.