### PR TITLE
Requested Life Path Change

### DIFF
--- a/code/datums/setup_option/backgrounds/path/path.dm
+++ b/code/datums/setup_option/backgrounds/path/path.dm
@@ -5,6 +5,8 @@
 	desc = "You used to work in the labour sector as a miner, janitor or anything else you could think of. \
 	This made you stronger and skilled at practical things but not very smart."
 
+	perks = list(PERK_NEAT)
+
 	stat_modifiers = list(STAT_ROB = 5, STAT_BIO = -5, STAT_MEC = 10, STAT_TGH = 5, STAT_COG = -5)
 
 /datum/category_item/setup_option/background/path/paper_worm


### PR DESCRIPTION
Added the "Humble Cleanser" perk to the Former Labourer lifepath. 
Reasoning being, working as an ex-janitor was mentioned in the life path text, and I am not confident enough in understanding of stat modifiers to create a new life path purely to add the Humble Cleanser perk in.