### PR TITLE
Fontaine+Custodian Map Removal

### DIFF
--- a/maps/__Liberty/map/_Liberty_Colony.dmm
+++ b/maps/__Liberty/map/_Liberty_Colony.dmm
@@ -244,11 +244,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/liberty/security/armoryshop)
-"adx" = (
-/obj/effect/window_lwall_spawn/smartspawn,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/liberty/bonfire/bioreactor)
 "adG" = (
 /obj/structure/grille,
 /obj/structure/grille,
@@ -888,19 +883,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild3,
 /area/liberty/crew_quarters)
-"alX" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
-	},
-/obj/structure/mirror{
-	pixel_x = 28
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/vectorrooms)
 "amk" = (
 /obj/structure/sign/department/medbay{
 	name = "CAPSA Hospital";
@@ -995,10 +977,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/liberty/security/range)
-"anb" = (
-/obj/structure/bed/chair/sofa/black/right,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/vectorrooms)
 "ang" = (
 /obj/random/traps/low_chance,
 /turf/simulated/mineral/planet,
@@ -1392,14 +1370,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/liberty/maintenance/undergroundfloor2east)
-"ari" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "arj" = (
 /obj/structure/filingcabinet/filingcabinet,
 /obj/effect/decal/cleanable/dirt,
@@ -1755,13 +1725,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/liberty/medical/sleeper)
-"auL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel/orangecorner,
-/area/liberty/hallway/surface/section1)
 "auP" = (
 /obj/effect/window_lwall_spawn/smartspawnplasma,
 /turf/simulated/floor/plating/under,
@@ -2083,15 +2046,6 @@
 /obj/effect/decal/cleanable/blood/drip,
 /turf/simulated/floor/wood/wild4,
 /area/liberty/dungeon/outside/hunter_cabin)
-"azE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "azP" = (
 /obj/machinery/light{
 	dir = 8
@@ -3091,8 +3045,8 @@
 	dir = 1;
 	pixel_y = -32
 	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/bioreactor)
+/turf/simulated/wall/r_wall,
+/area/liberty/hallway/surface/section1)
 "aLb" = (
 /obj/structure/table/rack/shelf,
 /obj/random/pouch/low_chance,
@@ -3115,15 +3069,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/liberty/maintenance/undergroundfloor3north)
-"aLz" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/storage)
 "aLB" = (
 /obj/structure/flora/small/snow/rock2,
 /turf/simulated/floor/snow,
@@ -3228,12 +3173,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/liberty/command/bridge)
-"aMj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "aMo" = (
 /obj/effect/floor_decal/spline/fancy,
 /obj/effect/floor_decal/industrial/danger{
@@ -3283,19 +3222,6 @@
 /obj/item/scrap_lump,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/liberty/engineering/engine_waste)
-"aMW" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/spline/fancy/corner{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "aMZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -3389,15 +3315,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/liberty/maintenance/undergroundfloor2east)
-"aOf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "aOt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
@@ -3438,10 +3355,6 @@
 "aOU" = (
 /turf/simulated/wall/r_wall,
 /area/liberty/security/detectives_office)
-"aOV" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/mineral,
-/area/colony)
 "aPd" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 4
@@ -3479,22 +3392,6 @@
 /obj/structure/medical_stand/anesthetic,
 /turf/simulated/floor/tiled/white/monofloor,
 /area/liberty/medical/surgery)
-"aPA" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 4
-	},
-/obj/effect/floor_decal/spline/fancy,
-/obj/effect/floor_decal/spline/fancy{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/storage)
 "aPB" = (
 /obj/structure/catwalk,
 /obj/structure/railing,
@@ -3718,7 +3615,7 @@
 	light_color = "#0892d0"
 	},
 /turf/simulated/floor/plating/under,
-/area/liberty/bonfire/bioreactor)
+/area/liberty/hallway/surface/section1)
 "aRy" = (
 /obj/machinery/shower{
 	dir = 8
@@ -4130,8 +4027,11 @@
 	pixel_y = -32
 	},
 /obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
 /turf/simulated/floor/plating/under,
-/area/liberty/bonfire/bioreactor)
+/area/liberty/hallway/surface/section1)
 "aXj" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_platform,
@@ -4268,16 +4168,6 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/liberty/quartermaster/hangarsupply)
-"aZe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/spline/fancy/corner,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/bioreactor)
 "aZf" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -4746,12 +4636,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/liberty/hallway/surface/section1)
-"beE" = (
-/obj/machinery/power/breakerbox{
-	RCon_tag = "Church Bypass"
-	},
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/liberty/bonfire/storage)
 "beG" = (
 /obj/machinery/vending/cigarette,
 /obj/machinery/holoposter{
@@ -4873,14 +4757,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/substation/medical)
-"bgs" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/obj/effect/floor_decal/spline/fancy{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "bgG" = (
 /obj/structure/flora/pottedplant/dead,
 /obj/effect/decal/cleanable/dirt,
@@ -4980,30 +4856,11 @@
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/liberty/crew_quarters/skyyard)
-"bhp" = (
-/obj/effect/floor_decal/industrial/box/white,
-/obj/structure/sign/faction/derelict1{
-	desc = "ATTENTION: The Bonfire is a highly dangerous piece of equipment, we recommend caution when using it. Appropiate use of fireproof Custodian voidsuits is paramount to avoid catching fire when operating the equipment and to prevent heavy injuries in the event of Scorch spillage.";
-	name = "NOTICE: Dangerous Equipment";
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/bioreactor)
 "bhq" = (
 /obj/random/closet_maintloot,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/liberty/maintenance/undergroundfloor2south)
-"bhy" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "bhE" = (
 /obj/structure/girder,
 /obj/item/material/shard/shrapnel/scrap,
@@ -5101,12 +4958,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/asteroid/grass,
 /area/liberty/medical/genetics)
-"bjh" = (
-/obj/structure/mopbucket,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/mop,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/storage)
 "bjj" = (
 /obj/structure/table/marble,
 /obj/item/reagent_containers/glass/beaker/large,
@@ -5209,14 +5060,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/liberty/hallway/surface/section1)
 "bkC" = (
@@ -5371,6 +5217,7 @@
 /obj/machinery/door/airlock/multi_tile/metal/mait{
 	dir = 2
 	},
+/obj/item/mine/improvised/armed,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/liberty/maintenance/undergroundfloor1east)
 "bmp" = (
@@ -5436,8 +5283,11 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
 	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/bioreactor)
+/area/liberty/hallway/surface/section1)
 "bnj" = (
 /obj/structure/sign/department/conference_room,
 /turf/simulated/wall/r_wall,
@@ -5784,15 +5634,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/rock,
 /area/liberty/maintenance/oldlibrary)
-"brb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance_common{
-	req_access = list(12)
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/vectorrooms)
 "brc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -7251,18 +7092,6 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/liberty/crew_quarters/sleep/cryo2)
-"bIN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/vectorrooms)
 "bIO" = (
 /obj/machinery/door/airlock/maintenance_common,
 /obj/effect/decal/cleanable/dirt,
@@ -7328,11 +7157,10 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/liberty/command/armory)
 "bJG" = (
-/obj/machinery/craftingstation,
-/obj/item/oddity/ls/manual,
 /obj/machinery/camera/network/engineering{
 	dir = 4
 	},
+/obj/structure/table/steel_reinforced,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/liberty/engineering/atmos/storage)
 "bJU" = (
@@ -7752,6 +7580,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/liberty/hallway/surface/section1)
 "bOo" = (
@@ -7941,19 +7770,6 @@
 /obj/item/material/butterfly/switchblade,
 /turf/simulated/floor/industrial/navy_slates,
 /area/liberty/maintenance/saloon)
-"bQe" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/spline/fancy{
-	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_pump,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "bQm" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/checker_large,
@@ -7984,6 +7800,9 @@
 /area/liberty/crew_quarters)
 "bQQ" = (
 /obj/machinery/light/floor,
+/obj/structure/bed/chair/office{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/liberty/engineering/atmos/storage)
 "bQV" = (
@@ -7993,10 +7812,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/undergroundfloor2west)
-"bRd" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating/under,
-/area/liberty/bonfire/vectorrooms)
 "bRf" = (
 /obj/effect/floor_decal/industrial/warningred,
 /obj/item/stool/padded,
@@ -8472,18 +8287,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating/under,
 /area/liberty/engineering/atmos/storage)
-"bVH" = (
-/obj/machinery/camera/network/custodians{
-	dir = 8
-	},
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 8
-	},
-/obj/effect/floor_decal/spline/fancy{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "bVK" = (
 /obj/effect/floor_decal/industrial/outline/red,
 /obj/structure/multiz/ladder/up,
@@ -8681,17 +8484,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/undergroundfloor2north)
-"bXX" = (
-/obj/structure/disposalpipe/junction{
-	dir = 4;
-	icon_state = "pipe-j2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "bYg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -9251,9 +9043,20 @@
 /turf/simulated/floor/tiled/dark/golden,
 /area/liberty/crew_quarters/skyyard)
 "cdM" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/liberty/bonfire/vectorrooms)
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/liberty/hallway/surface/section1)
 "cdO" = (
 /obj/random/mob/termite_no_despawn,
 /turf/simulated/floor/tiled/steel,
@@ -9517,11 +9320,6 @@
 	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/liberty/rnd/xenoflora)
-"chi" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/wood/wild1,
-/area/liberty/hallway/surface/section1)
 "chj" = (
 /obj/machinery/atm{
 	dir = 1;
@@ -9571,14 +9369,6 @@
 	},
 /turf/simulated/floor/rock/manmade/road,
 /area/liberty/outside/range)
-"chL" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "chN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/mob/nightmare/low_chance,
@@ -9732,19 +9522,6 @@
 /obj/effect/decal/cleanable/dirt/snow,
 /turf/simulated/floor/asteroid/dirt,
 /area/liberty/outside/forest)
-"cjQ" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/spline/fancy{
-	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "cjU" = (
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
@@ -9754,6 +9531,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/item/tool/wirecutters/improvised,
 /turf/simulated/floor/plating/under,
 /area/liberty/maintenance/undergroundfloor1east)
 "cjV" = (
@@ -10358,11 +10136,6 @@
 "cqw" = (
 /turf/simulated/mineral,
 /area/liberty/outside/forest)
-"cqx" = (
-/obj/effect/window_lwall_spawn/reinforced,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/liberty/bonfire/stronghold)
 "cqE" = (
 /obj/machinery/camera/network/security{
 	dir = 1
@@ -10691,9 +10464,6 @@
 /obj/item/tool/knife/ritual,
 /turf/simulated/floor/rock/manmade/concrete,
 /area/liberty/maintenance/undergroundfloor2north)
-"cuz" = (
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/bioreactor)
 "cuC" = (
 /obj/item/modular_computer/console/preset/engineering/shield,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
@@ -10835,14 +10605,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/liberty/crew_quarters/toilet)
-"cwg" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "cwh" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/carpet/turcarpet,
@@ -10916,18 +10678,6 @@
 	icon_state = "8,11"
 	},
 /area/shuttle/vasiliy_shuttle_area)
-"cxb" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/alarm{
-	pixel_y = 32
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/storage)
 "cxe" = (
 /obj/structure/plushie/beepsky,
 /turf/simulated/wall/r_wall,
@@ -10965,15 +10715,6 @@
 /obj/item/storage/box/flashbangs,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/liberty/security/tactical)
-"cxm" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/storage)
 "cxq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -10988,26 +10729,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/liberty/quartermaster/office)
-"cxs" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "cxw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -11186,23 +10907,6 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/liberty/pros/shuttle)
-"czH" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 4
-	},
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "czI" = (
 /obj/structure/shuttle_part/science{
 	icon_state = "10,20"
@@ -11371,20 +11075,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/liberty/hallway/surface/section1)
-"cBR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/unpowered/simple/wood/saloon{
-	name = "Church Foyer"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "cBT" = (
 /obj/structure/closet/crate/hydroponics,
 /obj/item/tool/shovel/spade,
@@ -11516,8 +11206,6 @@
 /area/liberty/command/cso)
 "cDz" = (
 /obj/structure/table/steel_reinforced,
-/obj/item/gun_upgrade/underbarrel/bipod,
-/obj/item/gun_upgrade/underbarrel/bipod,
 /obj/structure/sign/warning/nosmoking/small{
 	pixel_x = -25
 	},
@@ -11557,13 +11245,6 @@
 /obj/structure/flora/small/snow/boulder1,
 /turf/simulated/floor/snow,
 /area/liberty/outside/inside_colony)
-"cEu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/spline/fancy/corner{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/vectorrooms)
 "cEy" = (
 /obj/structure/bed/chair/office/light,
 /obj/effect/decal/cleanable/dirt,
@@ -11685,15 +11366,6 @@
 	icon_state = "10,1"
 	},
 /area/shuttle/vasiliy_shuttle_area)
-"cGa" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "cGb" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -11886,16 +11558,6 @@
 	icon_state = "13,15"
 	},
 /area/shuttle/rocinante_shuttle_area)
-"cHO" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 8
-	},
-/obj/effect/floor_decal/spline/fancy/corner{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/storage)
 "cHP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -12452,7 +12114,7 @@
 	dir = 1;
 	frequency = 1441;
 	name = "Tank Monitor";
-	sensors = list("n2_sensor"="Nitrogen","o2_sensor"="Oxygen","co2_sensor"="Carbon        Dioxide","tox_sensor"="Toxins","n2o_sensor"="Nitrous        Oxide","waste_sensor"="Gas        Mix        Tank")
+	sensors = list("n2_sensor"="Nitrogen","o2_sensor"="Oxygen","co2_sensor"="Carbon                Dioxide","tox_sensor"="Toxins","n2o_sensor"="Nitrous                Oxide","waste_sensor"="Gas                Mix                Tank")
 	},
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/liberty/engineering/atmos/surface)
@@ -12760,14 +12422,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/liberty/command/panic_room)
-"cRL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/vectorrooms)
 "cSb" = (
 /obj/structure/closet/wall_mounted/emcloset{
 	pixel_x = -32
@@ -12853,14 +12507,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/liberty/engineering/engine_room)
-"cSK" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/disposal,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/liberty/bonfire/vectorrooms)
 "cSP" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /obj/machinery/door/blast/regular/open{
@@ -13189,13 +12835,6 @@
 /obj/landmark/join/start/watchmen,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/liberty/security/main)
-"cWA" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "cWJ" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -13579,18 +13218,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/liberty/security/prisoncells)
-"dax" = (
-/obj/machinery/door/airlock/silver{
-	req_access = list(27);
-	name = "Custodians Commons"
-	},
-/obj/machinery/air_stopper,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance_common{
-	req_access = list(12)
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/vectorrooms)
 "daA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white/gray_perforated,
@@ -14273,13 +13900,6 @@
 "dgU" = (
 /turf/simulated/floor/asteroid/grass,
 /area/liberty/medical/genetics)
-"dgW" = (
-/obj/effect/floor_decal/spline/fancy{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/storage)
 "dhb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/item/device/radio/off{
@@ -14613,13 +14233,6 @@
 	opacity = 0
 	},
 /area/liberty/engineering/workshop)
-"djS" = (
-/obj/machinery/vending/snack,
-/obj/effect/floor_decal/spline/fancy{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/vectorrooms)
 "djU" = (
 /obj/structure/table/standard,
 /obj/machinery/newscaster{
@@ -15238,11 +14851,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/liberty/hallway/surface/section1)
 "drR" = (
@@ -15547,13 +15158,6 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/dark,
 /area/liberty/pros/shuttle)
-"dxd" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/disposal,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/vectorrooms)
 "dxi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/oddity/common/broken_glass,
@@ -16097,9 +15701,6 @@
 /turf/simulated/floor/carpet/sblucarpet,
 /area/liberty/maintenance/undergroundfloor1east)
 "dDR" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -16108,8 +15709,8 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/bioreactor)
+/turf/simulated/wall/r_wall,
+/area/liberty/hallway/surface/section1)
 "dDU" = (
 /obj/effect/floor_decal/industrial/stand_clear/white{
 	dir = 1
@@ -16315,13 +15916,6 @@
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/liberty/maintenance/sunkenclub)
-"dGm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/bioreactor)
 "dGr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/industrial/arrows/white{
@@ -17134,31 +16728,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/liberty/medical/reception)
-"dPz" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/spline/fancy/corner{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/bioreactor)
-"dPI" = (
-/obj/structure/window/reinforced,
-/obj/structure/bed/chair/sofa/black{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/vectorrooms)
 "dPJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -17178,20 +16747,11 @@
 /obj/item/folder/yellow,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/liberty/command/meeting_room)
-"dPR" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/storage)
 "dPY" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 8
 	},
-/obj/effect/floor_decal/industrial/road/curvebig3,
-/obj/effect/floor_decal/industrial/warningwhite,
+/obj/effect/floor_decal/industrial/road/curve4,
 /turf/simulated/floor/rock/manmade/road,
 /area/liberty/outside/inside_colony)
 "dQb" = (
@@ -17397,10 +16957,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/grey_slates,
 /area/liberty/maintenance/undergroundfloor1east)
-"dSF" = (
-/obj/effect/floor_decal/industrial/road/warning4,
-/turf/simulated/floor/rock/manmade/road,
-/area/liberty/outside/inside_colony)
 "dST" = (
 /obj/structure/catwalk,
 /obj/random/structures,
@@ -17671,13 +17227,6 @@
 /obj/item/trash/material/device,
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/undergroundfloor2west)
-"dVX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/spline/fancy{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "dVY" = (
 /obj/machinery/light/small,
 /obj/structure/table/standard,
@@ -18062,10 +17611,9 @@
 	pixel_y = 28
 	},
 /turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/bioreactor)
+/area/liberty/hallway/surface/section1)
 "ebA" = (
 /obj/structure/table/steel_reinforced,
-/obj/item/circuitboard/artificer_turret,
 /obj/item/cell/large/high,
 /obj/item/ammo_magazine/ammobox/light_rifle_257/scrap,
 /obj/item/ammo_magazine/ammobox/light_rifle_257/scrap,
@@ -18149,10 +17697,9 @@
 /turf/simulated/floor/wood/wild5,
 /area/liberty/maintenance/undergroundfloor1oldgarden)
 "ecH" = (
-/obj/machinery/door/firedoor,
-/obj/effect/window_lwall_spawn/smartspawn,
-/turf/simulated/floor/plating,
-/area/liberty/bonfire/bioreactor)
+/obj/structure/boulder,
+/turf/unsimulated/mineral,
+/area/colony)
 "ecI" = (
 /obj/structure/table/standard,
 /obj/item/device/lighting/toggleable/lamp,
@@ -18263,13 +17810,6 @@
 /obj/item/storage/toolbox/electrical,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/liberty/rnd/robotics)
-"eez" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/vectorrooms)
 "eeB" = (
 /obj/machinery/atmospherics/unary/vent_scrubber,
 /obj/effect/decal/cleanable/dirt,
@@ -18411,18 +17951,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/liberty/quartermaster/hangarsupply)
-"ehd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/spline/fancy{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "ehf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/material_ore,
@@ -18804,7 +18332,7 @@
 	input_side = 1
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/liberty/bonfire/bioreactor)
+/area/liberty/hallway/surface/section1)
 "ekL" = (
 /turf/unsimulated/mineral/transition,
 /area/liberty/outside/forest)
@@ -19183,13 +18711,6 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/liberty/quartermaster/office)
-"epz" = (
-/obj/structure/window/reinforced,
-/obj/structure/bed/chair/sofa/black/right{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/vectorrooms)
 "epC" = (
 /obj/random/mob/vox/low_chance,
 /turf/simulated/floor/rock,
@@ -19528,14 +19049,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/liberty/hallway/surface/section1)
-"eux" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/disposal,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/liberty/bonfire/vectorrooms)
 "euy" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/item/cell/large/potato,
@@ -19733,16 +19246,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/liberty/command/panic_room)
-"exD" = (
-/obj/machinery/door/bonfire{
-	name = "Cleaning supplies"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance_common{
-	req_access = list(12)
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/storage)
 "exE" = (
 /obj/machinery/light{
 	dir = 1
@@ -20464,18 +19967,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/checker_large,
 /area/liberty/maintenance/oldkitchen)
-"eGJ" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/spline/fancy{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "eGK" = (
 /obj/machinery/door/firedoor/multi_tile{
 	dir = 2
@@ -20606,12 +20097,6 @@
 	},
 /turf/simulated/floor/tiled/steel/violetcorener,
 /area/liberty/rnd/xenobiology)
-"eHU" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "eIc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -20812,6 +20297,7 @@
 /area/liberty/maintenance/undergroundfloor2north)
 "eJU" = (
 /obj/structure/table/steel,
+/obj/item/circuitboard/autolathe,
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/liberty/maintenance/undergroundfloor1east)
 "eJZ" = (
@@ -20980,15 +20466,6 @@
 /obj/item/ammo_casing/rod_bolt/rcd,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/liberty/maintenance/undergroundfloor3north)
-"eLt" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "eLw" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment{
@@ -21319,16 +20796,6 @@
 	},
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/liberty/engineering/atmos/surface)
-"ePP" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -32
-	},
-/obj/machinery/recharger,
-/obj/structure/table/woodentable,
-/obj/effect/floor_decal/spline/fancy,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/bioreactor)
 "ePQ" = (
 /obj/machinery/atmospherics/pipe/zpipe/down,
 /turf/simulated/open,
@@ -21565,16 +21032,6 @@
 	},
 /turf/simulated/floor/tiled/steel/monofloor,
 /area/liberty/crew_quarters/janitor)
-"eTS" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "eTY" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -22136,18 +21593,6 @@
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/liberty/crew_quarters/kitchen)
-"fbw" = (
-/obj/structure/disposalpipe/sortjunction/flipped{
-	dir = 4;
-	name = "Custodians - Bonfire processing";
-	sortType = "Custodians - Bonfire processing"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "fbx" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -22544,9 +21989,6 @@
 /obj/random/mob/roaches,
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/undergroundfloor2north)
-"ffy" = (
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/liberty/pros/shuttle)
 "ffC" = (
 /obj/structure/table/woodentable,
 /obj/item/device/lighting/toggleable/lantern,
@@ -23059,23 +22501,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/liberty/crew_quarters/barbackroom)
-"flI" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/holoposter{
-	pixel_y = -33
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "flK" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cargo,
@@ -23349,16 +22774,6 @@
 /obj/machinery/space_heater,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/liberty/hallway/surface/section1)
-"fnR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/liberty/bonfire/vectorrooms)
 "fnV" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -23669,12 +23084,6 @@
 	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/liberty/hallway/surface/section1)
-"frp" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/effect/window_lwall_spawn/reinforced,
-/turf/simulated/floor/plating,
-/area/liberty/bonfire/bioreactor)
 "frr" = (
 /obj/machinery/telecomms/relay/preset/telecomms,
 /turf/simulated/floor/tiled/white/techfloor_grid,
@@ -24212,19 +23621,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/undergroundfloor2north)
-"fyT" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 32
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "fzb" = (
 /obj/structure/flora/big/bush2,
 /turf/simulated/floor/asteroid/grass/jungle,
@@ -24843,11 +24239,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/liberty/hallway/side/f2section1)
 "fGB" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
+/obj/effect/window_lwall_spawn/reinforced,
+/turf/simulated/floor/plating,
+/area/liberty/hallway/surface/section1)
 "fGD" = (
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/blood{
@@ -24856,9 +24250,6 @@
 	},
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/liberty/maintenance/undergroundfloor3north)
-"fGF" = (
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/liberty/pros/shuttle)
 "fGG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
@@ -26359,15 +25750,6 @@
 	},
 /turf/simulated/floor/industrial/ornate,
 /area/liberty/maintenance/undergroundfloor2north)
-"fXX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/liberty/hallway/surface/section1)
 "fYc" = (
 /obj/structure/grille{
 	desc = "Keeps the ruffians out. Hopefully.";
@@ -26533,11 +25915,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating/under,
 /area/liberty/maintenance/substation/bridge)
-"fZK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "fZL" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -26549,18 +25926,6 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/liberty/security/armoryshop)
-"fZM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/spline/fancy{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "fZN" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -26582,20 +25947,6 @@
 /obj/effect/floor_decal/industrial/hatch/blue,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/liberty/quartermaster/hangarsupply)
-"gak" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/effect/floor_decal/spline/fancy/corner{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/vectorrooms)
 "gaC" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -26735,15 +26086,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/liberty/quartermaster/office)
-"gch" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/bioreactor)
 "gcp" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -26818,16 +26160,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/liberty/security/hut_cell1)
-"gcJ" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "gcL" = (
 /obj/structure/flora/small/trailrockb5,
 /obj/structure/reagent_dispensers/fueltank/derelict,
@@ -27327,13 +26659,6 @@
 /obj/structure/barricade,
 /turf/simulated/floor/plating/under,
 /area/liberty/maintenance/undergroundfloor2south)
-"gix" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/bioreactor)
 "giT" = (
 /obj/effect/floor_decal/industrial/danger{
 	dir = 8;
@@ -27480,15 +26805,6 @@
 	},
 /turf/simulated/floor/wood/wild2,
 /area/liberty/crew_quarters/hotsprings)
-"glk" = (
-/obj/effect/floor_decal/industrial/hatch,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/storage)
 "gll" = (
 /obj/effect/floor_decal/spline/plain,
 /obj/structure/disposalpipe/segment{
@@ -27702,13 +27018,6 @@
 /obj/structure/bed/chair/office/light,
 /turf/simulated/floor/wood,
 /area/liberty/command/courtroom)
-"gob" = (
-/obj/structure/bed/chair/office{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/techfloor_grid,
-/area/liberty/engineering/atmos/storage)
 "goc" = (
 /obj/effect/window_lwall_spawn/reinforced/polarized{
 	id = "BARA"
@@ -27888,14 +27197,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/liberty/command/cso)
-"gqC" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "gqG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/industrial/danger{
@@ -28283,20 +27584,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/liberty/maintenance/undergroundfloor3north)
-"gut" = (
-/obj/structure/disposalpipe/junction{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/orangecorner,
-/area/liberty/hallway/surface/section1)
 "guv" = (
 /turf/simulated/mineral,
 /area/liberty/maintenance/undergroundfloor1central)
@@ -28846,21 +28133,6 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/liberty/engineering/engine_room)
-"gAY" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 4
-	},
-/obj/effect/floor_decal/spline/fancy{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "gBb" = (
 /obj/effect/floor_decal/industrial/road/straight2,
 /obj/effect/decal/cleanable/dirt,
@@ -29155,21 +28427,6 @@
 /obj/structure/flora/snowgrass/rockandgrass,
 /turf/simulated/floor/snow,
 /area/liberty/outside/range)
-"gEJ" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "gEM" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -29847,20 +29104,6 @@
 /obj/item/handcuffs,
 /turf/simulated/floor/wood/wild4,
 /area/liberty/dungeon/outside/hunter_cabin)
-"gMd" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/bioreactor)
 "gMe" = (
 /obj/structure/table/glass,
 /obj/machinery/firealarm{
@@ -30151,23 +29394,15 @@
 /turf/simulated/floor/asteroid/grass,
 /area/liberty/maintenance/undergroundfloor1oldgarden)
 "gOY" = (
-/obj/machinery/door/bonfire{
-	name = "Custodians substation"
+/obj/structure/railing{
+	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/effect/floor_decal/spline/fancy{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/maintenance_common{
-	req_access = list(12)
-	},
-/turf/simulated/floor/plating,
-/area/liberty/bonfire/bioreactor)
+/turf/simulated/floor/tiled/dark/golden,
+/area/liberty/hallway/surface/section1)
 "gOZ" = (
 /obj/item/storage/box/lights/mixed,
 /obj/effect/spider/stickyweb,
@@ -30528,11 +29763,9 @@
 /area/liberty/command/bridge)
 "gTq" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/liberty/hallway/surface/section1)
 "gTt" = (
@@ -30760,11 +29993,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/liberty/medical/medbay/uppercor)
-"gVR" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "gVU" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -30783,23 +30011,6 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/liberty/security/sechall)
-"gWh" = (
-/obj/structure/bed/chair,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/bioreactor)
-"gWr" = (
-/obj/structure/disposalpipe/junction/yjunction{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/vectorrooms)
 "gWs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/glass{
@@ -31037,20 +30248,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/liberty/maintenance/undergroundfloor3east)
-"gYE" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "gYF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -31225,27 +30422,6 @@
 /obj/structure/table/steel_reinforced,
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/liberty/maintenance/undergroundfloor2north)
-"haP" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
-"haR" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/storage)
 "haV" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 24
@@ -31970,12 +31146,6 @@
 /obj/random/furniture/pottedplant,
 /turf/simulated/floor/wood,
 /area/liberty/medical/psych)
-"hkb" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "hkf" = (
 /obj/structure/railing{
 	dir = 8
@@ -31994,21 +31164,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/liberty/crew_quarters/techshop)
-"hko" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "hkp" = (
 /obj/structure/noticeboard/medical,
 /turf/simulated/wall/r_wall,
@@ -32168,12 +31323,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/liberty/quartermaster/disposaldrop)
-"hlX" = (
-/obj/structure/table/bench/wooden,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/spline/fancy,
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/vectorrooms)
 "hmh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/steel_reinforced,
@@ -33327,12 +32476,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/liberty/hallway/side/f2section1)
-"hyQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/spline/fancy/corner,
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/vectorrooms)
 "hyX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -33532,20 +32675,6 @@
 	},
 /turf/simulated/floor/industrial/blue_slates,
 /area/liberty/maintenance/undergroundfloor3west)
-"hAG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/bioreactor)
 "hAV" = (
 /obj/structure/bed/chair/office/light{
 	dir = 8;
@@ -33675,13 +32804,6 @@
 /obj/item/clothing/head/helmet/faceshield/altyn/ironhammer,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/liberty/security/tactical)
-"hCQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "hCV" = (
 /turf/simulated/floor/snow,
 /area/liberty/security/maingate_outside)
@@ -33780,7 +32902,7 @@
 "hEk" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/bioreactor)
+/area/liberty/hallway/surface/section1)
 "hEo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
@@ -33879,13 +33001,10 @@
 	dir = 8;
 	frequency = 1441;
 	name = "Tank Monitor";
-	sensors = list("n2_sensor"="Nitrogen","o2_sensor"="Oxygen","co2_sensor"="Carbon        Dioxide","tox_sensor"="Toxins","n2o_sensor"="Nitrous        Oxide","waste_sensor"="Gas        Mix        Tank")
+	sensors = list("n2_sensor"="Nitrogen","o2_sensor"="Oxygen","co2_sensor"="Carbon                Dioxide","tox_sensor"="Toxins","n2o_sensor"="Nitrous                Oxide","waste_sensor"="Gas                Mix                Tank")
 	},
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/liberty/engineering/atmos/surface)
-"hFu" = (
-/turf/simulated/mineral,
-/area/liberty/crew_quarters/hydroponics)
 "hFG" = (
 /obj/structure/table/steel,
 /turf/simulated/floor/tiled/techmaint,
@@ -34296,18 +33415,6 @@
 /obj/structure/flora/grass/green,
 /turf/unsimulated/wall/snow,
 /area/liberty/outside/forest)
-"hJR" = (
-/obj/machinery/door/airlock/maintenance_common{
-	req_access = list(12)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/vectorrooms)
 "hJW" = (
 /obj/random/mob/termite_no_despawn,
 /turf/simulated/floor/beach/water/flooded,
@@ -34672,17 +33779,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/liberty/crew_quarters/sleep/cryo2)
 "hPf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/effect/window_lwall_spawn/reinforced,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/floor_decal/spline/fancy/corner{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/vectorrooms)
+/turf/simulated/floor/plating,
+/area/liberty/hallway/surface/section1)
 "hPo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -34759,20 +33861,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/concrete_bricks,
 /area/liberty/maintenance/undergroundfloor1east)
-"hQx" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/storage)
 "hQy" = (
 /obj/structure/grille{
 	desc = "Keeps the ruffians out. Hopefully.";
@@ -34904,17 +33992,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_panels,
 /area/liberty/maintenance/undergroundfloor2east)
-"hRx" = (
-/obj/machinery/alarm{
-	pixel_y = 32
-	},
-/obj/structure/disposalpipe/junction/yjunction,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "hRA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
@@ -35011,16 +34088,6 @@
 /obj/structure/flora/grass/green,
 /turf/unsimulated/wall/snow,
 /area/liberty/outside/forest)
-"hSS" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "hSU" = (
 /obj/structure/table/steel,
 /obj/machinery/recharger,
@@ -35245,7 +34312,7 @@
 	operating = 1
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/liberty/bonfire/bioreactor)
+/area/liberty/hallway/surface/section1)
 "hWc" = (
 /obj/machinery/atmospherics/unary/freezer{
 	dir = 4;
@@ -35381,16 +34448,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/liberty/rnd/xenobiology)
-"hXJ" = (
-/obj/structure/invislight,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/blast/regular/open{
-	id = "Colony Lockdown";
-	name = "Colony Lockdown"
-	},
-/obj/effect/window_lwall_spawn/reinforced,
-/turf/simulated/floor/plating,
-/area/liberty/bonfire/vectorrooms)
 "hXN" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4
@@ -35600,18 +34657,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/liberty/hallway/surface/section1)
-"ibr" = (
-/obj/structure/disposalpipe/sortjunction/flipped{
-	dir = 2;
-	name = "Custodians - Workshop";
-	sortType = "Custodians - Workshop"
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "ibu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -35789,15 +34834,6 @@
 /obj/item/remains/xeno,
 /turf/simulated/floor/rock,
 /area/liberty/maintenance/northcave)
-"idM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/vectorrooms)
 "idN" = (
 /obj/effect/floor_decal/industrial/caution{
 	dir = 8
@@ -36108,21 +35144,6 @@
 /obj/effect/decal/cleanable/filth,
 /turf/simulated/floor/wood/wild4,
 /area/liberty/maintenance/hideout)
-"iiJ" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/floor_decal/spline/fancy{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "iiP" = (
 /obj/structure/boulder,
 /obj/structure/boulder,
@@ -37036,12 +36057,6 @@
 "isO" = (
 /turf/simulated/wall/r_wall,
 /area/liberty/quartermaster/fightclub)
-"isS" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "itc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/mecha_armor,
@@ -37088,13 +36103,6 @@
 /obj/item/device/lighting/toggleable/lamp/green,
 /turf/simulated/floor/wood/wild4,
 /area/liberty/dungeon/outside/hunter_cabin)
-"itP" = (
-/obj/structure/table/woodentable,
-/obj/effect/floor_decal/spline/fancy{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/vectorrooms)
 "itU" = (
 /turf/simulated/shuttle/floor/mining{
 	icon_state = "9,23"
@@ -37392,19 +36400,6 @@
 /obj/item/caution/cone,
 /turf/simulated/floor/industrial/blue_slates_long,
 /area/liberty/maintenance/oldpool)
-"iws" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/spline/fancy/corner{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "iwD" = (
 /obj/structure/flora/small/snow/rock8,
 /turf/simulated/floor/snow,
@@ -37670,17 +36665,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/liberty/security/sechall)
-"izg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/floor{
-	dir = 8;
-	pixel_x = 15
-	},
-/obj/effect/floor_decal/spline/fancy{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "izh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -37871,23 +36855,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/liberty/hallway/side/f2section1)
-"iBu" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/spline/fancy/corner{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "iBv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -38057,15 +37024,6 @@
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/liberty/dungeon/outside/campground)
-"iDQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "iDR" = (
 /obj/structure/flora/tree/snow/five,
 /obj/structure/flora/small/snow/rock1,
@@ -38390,18 +37348,6 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/liberty/maintenance/sunkenclub)
-"iIm" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/spline/fancy{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "iIo" = (
 /obj/structure/bed/padded,
 /turf/simulated/floor/tiled/dark,
@@ -38607,13 +37553,6 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/liberty/engineering/atmos/storage)
-"iKO" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/vectorrooms)
 "iKS" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/barricade,
@@ -39669,7 +38608,7 @@
 	},
 /obj/structure/railing,
 /turf/simulated/floor/plating/under,
-/area/liberty/bonfire/bioreactor)
+/area/liberty/hallway/surface/section1)
 "iYR" = (
 /obj/random/mob/roaches/low_chance,
 /turf/simulated/floor/asteroid/dirt/mud,
@@ -40118,14 +39057,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/substation/bridge)
-"jdn" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "jdo" = (
 /obj/structure/flora/snowgrass/vegetation,
 /turf/simulated/floor/snow,
@@ -40136,7 +39067,7 @@
 /area/liberty/maintenance/saloon)
 "jdr" = (
 /obj/structure/catwalk,
-/obj/machinery/craftingstation,
+/obj/machinery/constructable_frame/machine_frame,
 /turf/simulated/floor/tiled/dark,
 /area/liberty/maintenance/undergroundfloor1east)
 "jdA" = (
@@ -40231,13 +39162,6 @@
 /obj/structure/multiz/stairs/enter/bottom,
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/oldmining)
-"jeJ" = (
-/obj/structure/toilet,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/vectorrooms)
 "jeQ" = (
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/liberty/rnd/lab)
@@ -40455,13 +39379,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild1,
 /area/liberty/maintenance/oldlibrary)
-"jhX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "jhZ" = (
 /obj/random/boxes,
 /obj/random/gun_energy_cheap/low_chance,
@@ -41050,13 +39967,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/liberty/quartermaster/disposaldrop)
-"jot" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/spline/fancy{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "jov" = (
 /obj/random/cluster/roaches,
 /obj/effect/decal/cleanable/dirt,
@@ -41252,19 +40162,6 @@
 	name = "murky water"
 	},
 /area/liberty/maintenance/undergroundfloor2south)
-"jrJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/floor_decal/spline/fancy{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/vectorrooms)
 "jrQ" = (
 /obj/structure/table/standard,
 /obj/random/cloth/glasses/low_chance,
@@ -41293,20 +40190,6 @@
 	},
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/liberty/command/meeting_room)
-"jsd" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/spline/fancy{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/storage)
 "jsi" = (
 /obj/structure/table/rack/shelf,
 /obj/random/material/low_chance,
@@ -41572,7 +40455,7 @@
 /area/liberty/crew_quarters/bar)
 "jvb" = (
 /turf/simulated/wall/r_wall,
-/area/liberty/bonfire/storage)
+/area/liberty/maintenance/undergroundfloor1north)
 "jvc" = (
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/liberty/rnd/xenobiology)
@@ -41703,21 +40586,8 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/liberty/hallway/side/f2section1)
-"jwO" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "jwP" = (
 /obj/structure/table/steel_reinforced,
-/obj/item/circuitboard/artificer_turret,
 /obj/item/cell/large/high,
 /obj/item/ammo_magazine/ammobox/light_rifle_257/scrap,
 /obj/item/ammo_magazine/ammobox/light_rifle_257/scrap,
@@ -42039,14 +40909,6 @@
 	name = "murky water"
 	},
 /area/liberty/maintenance/cavenightmare)
-"jAM" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/storage)
 "jAP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -42876,9 +41738,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/substation/bridge)
-"jKQ" = (
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/vectorrooms)
 "jKR" = (
 /obj/machinery/power/terminal{
 	dir = 8
@@ -43306,14 +42165,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/liberty/maintenance/undergroundfloor2west)
-"jPY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/network/custodians,
-/obj/effect/floor_decal/spline/fancy{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "jQe" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
 	dir = 4
@@ -43346,20 +42197,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/liberty/medical/sleeper)
-"jQK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "jQW" = (
 /obj/effect/window_lwall_spawn/plasma/reinforced,
 /obj/machinery/door/firedoor,
@@ -43539,22 +42376,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/liberty/command/swo/quarters)
-"jSW" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "jTc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -44238,7 +43059,7 @@
 	sort_tag = "Engineering - Recycler"
 	},
 /turf/simulated/floor/plating/under,
-/area/liberty/bonfire/bioreactor)
+/area/liberty/hallway/surface/section1)
 "jZU" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/light,
@@ -44398,10 +43219,6 @@
 /turf/simulated/floor/asteroid/grass,
 /area/liberty/maintenance/undergroundfloor1oldgarden)
 "kbk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /obj/effect/floor_decal/industrial/box/white/corners{
 	dir = 8
 	},
@@ -44416,31 +43233,16 @@
 	},
 /obj/effect/floor_decal/industrial/warningwhite,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/bioreactor)
+/area/liberty/hallway/surface/section1)
 "kbn" = (
 /obj/machinery/disposal,
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/liberty/maintenance/sunkenclub)
-"kbo" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "kbu" = (
 /obj/machinery/constructable_frame/machine_frame{
 	state = 2
@@ -44482,23 +43284,6 @@
 	},
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/liberty/rnd/robotics)
-"kcb" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/storage)
 "kcd" = (
 /obj/machinery/button/remote/airlock{
 	id = "panicRoom";
@@ -44903,13 +43688,10 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/undergroundfloor2west)
 "khU" = (
-/obj/machinery/atmospherics/unary/vent_scrubber,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/liberty/bonfire/vectorrooms)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/liberty/hallway/surface/section1)
 "khX" = (
 /obj/structure/flora/small/snow/rock2,
 /obj/structure/flora/tree/snow/snow,
@@ -44952,24 +43734,7 @@
 /turf/simulated/floor/tiled/white/monofloor,
 /area/liberty/medical/organ_lab)
 "kin" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 4
-	},
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
+)
 "kit" = (
 /obj/effect/floor_decal/industrial/warningred{
 	dir = 4
@@ -45214,13 +43979,6 @@
 /obj/random/traps/low_chance,
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/undergroundfloor3north)
-"kls" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/spline/fancy{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "klv" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/floor_decal/spline/fancy/three_quarters,
@@ -46219,15 +44977,6 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/liberty/crew_quarters/hydroponics)
-"kwY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "kxf" = (
 /obj/structure/toilet,
 /obj/structure/window/reinforced{
@@ -46289,13 +45038,6 @@
 /obj/structure/flora/small/grassb5,
 /turf/simulated/floor/asteroid/grass,
 /area/liberty/hallway/surface/section1)
-"kxu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/orangecorner,
-/area/liberty/hallway/surface/section1)
 "kxA" = (
 /obj/structure/table/steel,
 /obj/random/lowkeyrandom/low_chance,
@@ -46354,11 +45096,6 @@
 	},
 /turf/simulated/floor/carpet/turcarpet,
 /area/liberty/maintenance/arcade)
-"kyA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/liberty/bonfire/vectorrooms)
 "kyD" = (
 /obj/machinery/craftingstation,
 /obj/item/stack/material/cardboard/full,
@@ -46948,12 +45685,6 @@
 /obj/random/mob/roaches/low_chance,
 /turf/simulated/floor/industrial/black_large_slates,
 /area/liberty/maintenance/undergroundfloor1north)
-"kGI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "kGO" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -47001,10 +45732,6 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/maint_merc)
-"kHV" = (
-/obj/structure/table/woodentable,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/vectorrooms)
 "kHX" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin{
@@ -47273,11 +46000,6 @@
 	icon_state = "5,16"
 	},
 /area/shuttle/vasiliy_shuttle_area)
-"kLD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating/under,
-/area/liberty/bonfire/vectorrooms)
 "kLE" = (
 /obj/effect/floor_decal/industrial/danger{
 	dir = 8;
@@ -47350,10 +46072,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/machinery/door/airlock/mining{
-	name = "Fontaine Prep";
-	req_access = list(78)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -47565,22 +46283,6 @@
 /obj/random/structures/low_chance,
 /turf/simulated/floor/plating/under,
 /area/liberty/maintenance/undergroundfloor2south)
-"kOu" = (
-/obj/random/furniture/pottedplant,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 32
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc/inactive{
-	name = "North APC";
-	pixel_y = 28
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "kOw" = (
 /obj/machinery/light_switch{
 	pixel_y = 32
@@ -47926,13 +46628,6 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/liberty/security/armory)
-"kSm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "kSD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -48036,18 +46731,6 @@
 /obj/structure/boulder,
 /turf/simulated/floor/rock,
 /area/liberty/maintenance/caveagape)
-"kUb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "kUf" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -48071,19 +46754,6 @@
 /obj/machinery/space_heater,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/liberty/maintenance/undergroundfloor3north)
-"kUp" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating/under,
-/area/liberty/bonfire/storage)
 "kUv" = (
 /obj/structure/window/reinforced,
 /obj/machinery/light{
@@ -48322,15 +46992,6 @@
 /obj/structure/barricade,
 /turf/simulated/floor/wood/wild1,
 /area/liberty/dungeon/outside/campground)
-"kWq" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 1
-	},
-/obj/machinery/camera/network/custodians{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "kWu" = (
 /obj/random/scrap/dense_weighted/low_chance,
 /turf/simulated/floor/tiled/white/brown_perforated,
@@ -48450,11 +47111,6 @@
 /obj/machinery/camera/network/command,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/liberty/command/tcommsat/computer)
-"kYa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/industrial/loading/white,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/bioreactor)
 "kYl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -49002,13 +47658,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/liberty/command/bridge)
-"lfX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/window_lwall_spawn/reinforced,
-/turf/simulated/floor/plating,
-/area/liberty/bonfire/stronghold)
 "lgj" = (
 /obj/random/scrap/sparse_even/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -49423,11 +48072,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/liberty/maintenance/undergroundfloor2north)
-"llh" = (
-/obj/machinery/atmospherics/unary/vent_pump,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "lli" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -49740,11 +48384,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/liberty/quartermaster/miningdock)
-"lpM" = (
-/obj/machinery/door/firedoor,
-/obj/effect/window_lwall_spawn/reinforced,
-/turf/simulated/floor/plating,
-/area/liberty/bonfire/bioreactor)
 "lpU" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -49950,29 +48589,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild3,
 /area/liberty/crew_quarters)
-"lsd" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 4
-	},
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 8
-	},
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 9
-	},
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "lse" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 4
@@ -51417,18 +50033,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/quartermaster/fightclub)
-"lKi" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "lKj" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/structure/disposalpipe/segment,
@@ -51969,11 +50573,6 @@
 	},
 /obj/structure/cable/cyan{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
@@ -52071,19 +50670,6 @@
 	},
 /turf/simulated/floor/industrial/bricks,
 /area/liberty/maintenance/undergroundfloor2north)
-"lQo" = (
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/sensor{
-	long_range = 1;
-	name = "Powernet Sensor - Custodian Subgrid";
-	name_tag = "Cust Subgrid"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/storage)
 "lQp" = (
 /obj/machinery/light{
 	dir = 8
@@ -52211,10 +50797,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/blue_slates,
 /area/liberty/maintenance/undergroundfloor2north)
-"lSv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "lSz" = (
 /obj/structure/table/woodentable,
 /obj/effect/decal/cleanable/dirt,
@@ -52561,12 +51143,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/liberty/engineering/engine_room)
-"lWp" = (
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "lWq" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 4
@@ -52715,20 +51291,6 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/liberty/maintenance/sunkenclub)
-"lXR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/liberty/bonfire/vectorrooms)
 "lXV" = (
 /obj/machinery/camera/network/research{
 	dir = 8
@@ -52743,17 +51305,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/cafe_large,
 /area/liberty/maintenance/undergroundfloor2north)
-"lYc" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "lYh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atm{
@@ -52823,15 +51374,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/liberty/hallway/side/f2section1)
-"mad" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/storage)
 "mah" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
@@ -53157,18 +51699,6 @@
 	},
 /turf/simulated/floor/rock/manmade/road,
 /area/liberty/outside/range)
-"mdI" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "mdT" = (
 /obj/machinery/atm{
 	dir = 4;
@@ -53381,9 +51911,6 @@
 /obj/structure/flora/small/trailrocka4,
 /turf/simulated/floor/asteroid/grass,
 /area/liberty/maintenance/substation/sec)
-"mfH" = (
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "mgd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
@@ -53787,10 +52314,6 @@
 "mnl" = (
 /turf/simulated/wall/r_wall,
 /area/liberty/medical/organ_lab)
-"mnp" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/wall/r_wall,
-/area/liberty/bonfire/stronghold)
 "mnq" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -53829,19 +52352,6 @@
 "mnU" = (
 /turf/simulated/mineral/planet,
 /area/liberty/maintenance/undergroundfloor1oldgarden)
-"mod" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating/under,
-/area/liberty/bonfire/vectorrooms)
 "moh" = (
 /obj/effect/decal/cleanable/vomit,
 /obj/effect/decal/cleanable/dirt,
@@ -54081,9 +52591,6 @@
 /obj/machinery/computer/cryopod/elevator,
 /turf/simulated/wall/r_wall,
 /area/liberty/crew_quarters/sleep/cryo2)
-"mrD" = (
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/storage)
 "mrE" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -54819,12 +53326,6 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/liberty/hallway/surface/section1)
-"mBk" = (
-/obj/machinery/door/airlock/maintenance_common{
-	req_access = list(12)
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/vectorrooms)
 "mBu" = (
 /obj/effect/decal/cleanable/blood{
 	blood_color = "#A10808";
@@ -54859,12 +53360,6 @@
 	},
 /turf/simulated/floor/wood/wild1,
 /area/liberty/crew_quarters/dorm1)
-"mCg" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/vectorrooms)
 "mCm" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -54973,12 +53468,6 @@
 	},
 /turf/simulated/floor/reinforced/oxygen,
 /area/liberty/engineering/atmos)
-"mEA" = (
-/obj/effect/floor_decal/spline/fancy{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/vectorrooms)
 "mEB" = (
 /obj/structure/table/rack,
 /obj/item/towel,
@@ -55863,7 +54352,6 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/holoposter{
 	pixel_x = -30
 	},
@@ -55872,7 +54360,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/bioreactor)
+/area/liberty/hallway/surface/section1)
 "mOW" = (
 /turf/simulated/wall/rust_reinforced,
 /area/liberty/maintenance/undergroundfloor3north)
@@ -55914,15 +54402,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
 /area/liberty/rnd/xenoflora)
-"mPm" = (
-/obj/effect/floor_decal/industrial/hatch,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/storage)
 "mPt" = (
 /turf/simulated/wall/r_wall,
 /area/colony)
@@ -56046,16 +54525,13 @@
 /turf/simulated/floor/tiled/white,
 /area/shuttle/rocinante_shuttle_area)
 "mRu" = (
-/obj/machinery/door/unpowered/simple/wood/saloon{
-	name = "Church Foyer"
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/stronghold)
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/liberty/hallway/surface/section1)
 "mRv" = (
 /obj/effect/decal/cleanable/dirt/snow,
 /turf/simulated/floor/rock/manmade/asphalt,
@@ -56083,13 +54559,6 @@
 	},
 /turf/simulated/floor/wood/wild1,
 /area/liberty/crew_quarters/dorm1)
-"mRT" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/vectorrooms)
 "mRU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -56346,10 +54815,6 @@
 /obj/machinery/suit_storage_unit/engineering/atmos,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/liberty/rnd/server)
-"mUK" = (
-/obj/machinery/space_heater,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "mUL" = (
 /obj/structure/curtain/open/bed,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -56433,10 +54898,6 @@
 /obj/machinery/air_stopper,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/liberty/hallway/surface/section1)
-"mVB" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "mVJ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/wall/r_wall,
@@ -56763,13 +55224,6 @@
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/liberty/crew_quarters/dorm2)
-"nag" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance_common{
-	req_access = list(12)
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/vectorrooms)
 "nah" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
@@ -56839,7 +55293,7 @@
 	operating = 1
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/liberty/bonfire/bioreactor)
+/area/liberty/hallway/surface/section1)
 "nbq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -56858,18 +55312,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/undergroundfloor3east)
-"nbu" = (
-/obj/machinery/firealarm{
-	pixel_y = 32
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/storage)
 "nbw" = (
 /turf/simulated/shuttle/wall/escpod{
 	dir = 4;
@@ -57010,22 +55452,11 @@
 	},
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/liberty/crew_quarters/sleep/cryo2)
-"nde" = (
-/obj/machinery/camera/network/custodians{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/storage)
 "nds" = (
 /obj/structure/boulder,
 /obj/effect/decal/cleanable/dirt/snow,
 /turf/simulated/floor/plating/under,
 /area/liberty/maintenance/undergroundfloor2west)
-"ndy" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/vectorrooms)
 "ndA" = (
 /obj/machinery/disposal,
 /obj/effect/floor_decal/industrial/box/red,
@@ -57092,13 +55523,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/undergroundfloor3south)
-"nef" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/carbon/superior_animal/giant_spider/nurse/cave_spider,
-/obj/item/clothing/under/costume/kinky/sexy_mime,
-/obj/item/clothing/mask/costume/kinky/sexy_mime,
-/turf/simulated/floor/wood,
-/area/liberty/bonfire/vectorrooms)
 "neg" = (
 /obj/structure/grille{
 	desc = "Keeps the ruffians out. Hopefully.";
@@ -57903,8 +56327,16 @@
 /turf/simulated/floor/tiled/dark/greencorner,
 /area/liberty/medical/genetics)
 "nnh" = (
-/turf/simulated/floor/plating/under,
-/area/liberty/bonfire/storage)
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/spline/fancy{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/liberty/hallway/surface/section1)
 "nnn" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
@@ -57951,10 +56383,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/liberty/storage/primary)
-"nnD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "nnS" = (
 /obj/random/closet_tech,
 /obj/machinery/light/small{
@@ -58283,10 +56711,6 @@
 	},
 /turf/simulated/floor/industrial/fancy_slates,
 /area/liberty/maintenance/undergroundfloor3north)
-"nrl" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/storage)
 "nry" = (
 /obj/structure/catwalk,
 /obj/structure/cable/cyan{
@@ -58800,13 +57224,6 @@
 /obj/structure/boulder,
 /turf/simulated/wall/r_wall,
 /area/liberty/maintenance/undergroundfloor3north)
-"nxn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/spline/fancy/corner{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "nxq" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -58819,25 +57236,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/golden,
 /area/liberty/crew_quarters/skyyard)
-"nxr" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/spline/fancy{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/storage)
 "nxs" = (
 /obj/structure/table/woodentable,
 /obj/item/reagent_containers/food/drinks/drinkingglass,
@@ -59036,17 +57434,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/green_large_slates,
 /area/liberty/maintenance/undergroundfloor2east)
-"nzU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/vectorrooms)
 "nAc" = (
 /obj/structure/sign/departmentold/mining,
 /turf/simulated/wall/r_wall,
@@ -59103,11 +57490,6 @@
 "nAR" = (
 /turf/unsimulated/wall/snow,
 /area/liberty/outside/inside_colony)
-"nBc" = (
-/obj/effect/floor_decal/industrial/loading/white,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/bioreactor)
 "nBe" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/unsimulated/mineral,
@@ -59498,10 +57880,6 @@
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/liberty/hallway/surface/section1)
-"nGq" = (
-/obj/effect/floor_decal/industrial/hatch,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/storage)
 "nGu" = (
 /obj/machinery/power/sensor{
 	long_range = 1;
@@ -59849,10 +58227,6 @@
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/liberty/crew_quarters/bar)
-"nJD" = (
-/obj/structure/bed/chair/sofa/black,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/vectorrooms)
 "nJK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -59989,7 +58363,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/decor_light/pyre,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/liberty/hallway/surface/section1)
 "nLw" = (
@@ -60058,11 +58431,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/liberty/quartermaster/miningdock)
-"nME" = (
-/obj/structure/table/woodentable,
-/obj/effect/floor_decal/spline/fancy,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/bioreactor)
 "nMJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -60125,12 +58493,6 @@
 /obj/structure/boulder,
 /turf/simulated/floor/snow,
 /area/liberty/maintenance/caveameridian)
-"nNM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/vectorrooms)
 "nNO" = (
 /turf/simulated/shuttle/wall/science{
 	icon_state = "12,9"
@@ -60407,7 +58769,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/liberty/bonfire/bioreactor)
+/area/liberty/hallway/surface/section1)
 "nPR" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
@@ -60467,18 +58829,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/liberty/command/courtroom)
-"nQw" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/storage)
 "nQy" = (
 /mob/living/simple_animal/hostile/hivebot/range,
 /turf/simulated/floor/asteroid/dirt,
@@ -60746,20 +59096,6 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/liberty/security/sechall)
-"nTx" = (
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/effect/floor_decal/spline/fancy{
-	dir = 4
-	},
-/obj/machinery/power/apc/inactive{
-	name = "North APC";
-	pixel_y = 28
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/storage)
 "nTy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -60928,20 +59264,6 @@
 /obj/item/scrap_lump,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/liberty/engineering/engine_waste)
-"nVD" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/bioreactor)
 "nVE" = (
 /obj/machinery/atmospherics/pipe/tank/air,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
@@ -61016,13 +59338,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/liberty/medical/medbay/uppercor)
-"nWX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "nXe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -61202,17 +59517,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/liberty/medical/organ_lab)
-"nZG" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "nZI" = (
 /obj/effect/window_lwall_spawn/smartspawn/church,
 /turf/simulated/floor/plating,
@@ -61437,12 +59741,6 @@
 /obj/random/mob/roaches,
 /turf/simulated/floor/industrial/white_large_slates,
 /area/liberty/maintenance/undergroundfloor1west)
-"ocL" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/effect/window_lwall_spawn/reinforced,
-/turf/simulated/floor/plating,
-/area/liberty/bonfire/bioreactor)
 "ocM" = (
 /obj/machinery/door/airlock/maintenance_common,
 /obj/structure/disposalpipe/segment{
@@ -61605,14 +59903,7 @@
 /turf/simulated/floor/wood/wild3,
 /area/liberty/crew_quarters)
 "ofg" = (
-/obj/structure/bookcase/guncase,
-/obj/random/gun_parts,
-/obj/random/gun_parts,
-/obj/random/gun_parts,
-/obj/random/gun_parts,
-/obj/random/gun_parts,
-/obj/item/ammo_kit,
-/obj/item/ammo_kit,
+/obj/structure/table/steel_reinforced,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/liberty/engineering/atmos/storage)
 "ofj" = (
@@ -62084,10 +60375,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/checker_large,
 /area/liberty/maintenance/oldkitchen)
-"ojV" = (
-/obj/random/mob/tengolo,
-/turf/simulated/floor/rock,
-/area/liberty/outside/bcave)
 "ojY" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -62218,25 +60505,6 @@
 /obj/item/device/camera_film,
 /turf/simulated/floor/wood,
 /area/liberty/maintenance/undergroundfloor2east)
-"olE" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/obj/effect/floor_decal/spline/fancy{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
-"olM" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/vectorrooms)
 "olR" = (
 /obj/structure/table/rack/shelf,
 /obj/random/pack/cloth/low_chance,
@@ -62813,11 +61081,6 @@
 /obj/random/closet_maintloot/low_chance,
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/undergroundfloor1north)
-"osj" = (
-/obj/structure/table/steel_reinforced,
-/obj/item/circuitboard/puncher,
-/turf/simulated/floor/tiled/steel/techfloor_grid,
-/area/liberty/engineering/atmos/storage)
 "osm" = (
 /obj/machinery/power/apc/inactive{
 	name = "East APC";
@@ -64997,17 +63260,6 @@
 	},
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/turret_protected/ai)
-"oPQ" = (
-/obj/machinery/door/unpowered/simple/wood/saloon{
-	name = "Church Foyer"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/stronghold)
 "oPY" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -65306,17 +63558,6 @@
 	},
 /turf/simulated/floor/tiled/white/techfloor,
 /area/liberty/quartermaster/disposaldrop)
-"oTn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/spline/fancy,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "oTs" = (
 /obj/structure/table/woodentable,
 /obj/item/flame/candle{
@@ -65555,21 +63796,6 @@
 /obj/structure/barricade,
 /turf/simulated/floor/wood/wild1,
 /area/liberty/maintenance/oldlibrary)
-"oWI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/light/floor{
-	dir = 8
-	},
-/obj/effect/floor_decal/spline/fancy{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "oWM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -66036,18 +64262,6 @@
 	},
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/liberty/medical/sleeper)
-"pcr" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "pcw" = (
 /obj/structure/bed/chair/sofa/black/right{
 	pixel_x = -1
@@ -66165,15 +64379,6 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/asteroid/grass,
 /area/liberty/hallway/side/f2section1)
-"pdE" = (
-/obj/machinery/disposal,
-/obj/effect/floor_decal/industrial/box/red,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "pdG" = (
 /obj/structure/boulder,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -66332,13 +64537,6 @@
 /obj/effect/window_lwall_spawn,
 /turf/simulated/floor/plating,
 /area/liberty/maintenance/saloon)
-"pfw" = (
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 26
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/storage)
 "pfx" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -66403,17 +64601,6 @@
 /obj/machinery/light/floor,
 /turf/simulated/floor/tiled/steel,
 /area/liberty/command/courtroom)
-"pgl" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/light/floor{
-	pixel_y = 5
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/storage)
 "pgv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -67400,12 +65587,6 @@
 	},
 /turf/simulated/floor/industrial/blue_slates,
 /area/liberty/maintenance/undergroundfloor3west)
-"psQ" = (
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/disposal,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/vectorrooms)
 "psW" = (
 /obj/machinery/washing_machine,
 /obj/machinery/holoposter{
@@ -67415,10 +65596,6 @@
 	dir = 4
 	},
 /area/liberty/crew_quarters/toilet)
-"ptb" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating/under,
-/area/liberty/bonfire/storage)
 "ptk" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
@@ -67503,16 +65680,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/undergroundfloor2north)
-"pui" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/unpowered/simple/wood/saloon{
-	name = "Church Foyer"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "pun" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/hologram/holopad,
@@ -67752,10 +65919,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/blue_slates,
 /area/liberty/maintenance/undergroundfloor2north)
-"pxa" = (
-/obj/machinery/atmospherics/unary/vent_scrubber,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "pxd" = (
 /turf/simulated/wall/r_wall,
 /area/liberty/crew_quarters/barbackroom)
@@ -68099,11 +66262,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/liberty/maintenance/undergroundfloor3north)
-"pAO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "pAR" = (
 /obj/random/junk/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -68122,20 +66280,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/liberty/engineering/workshop)
-"pBd" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "pBl" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 1
@@ -68565,11 +66709,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/liberty/crew_quarters/barbackroom)
-"pGV" = (
-/obj/machinery/atmospherics/unary/vent_scrubber,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/storage)
 "pGX" = (
 /obj/structure/table/glass,
 /obj/item/storage/firstaid/o2,
@@ -68607,24 +66746,6 @@
 "pHn" = (
 /turf/unsimulated/mineral,
 /area/liberty/outside/range)
-"pHq" = (
-/obj/machinery/door/airlock/silver{
-	req_access = list(27);
-	name = "Custodians Commons"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/air_stopper,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance_common{
-	req_access = list(12)
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/vectorrooms)
 "pHs" = (
 /obj/structure/shuttle_part/science{
 	icon_state = "0,4"
@@ -68945,16 +67066,6 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/liberty/maintenance/caveameridian)
-"pKJ" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/bioreactor)
 "pKM" = (
 /obj/machinery/camera/network/command{
 	dir = 4
@@ -68978,13 +67089,12 @@
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/liberty/medical/cryo)
 "pKR" = (
-/obj/machinery/shower{
-	dir = 1
+/obj/machinery/door/airlock/maintenance_engineering{
+	name = "Engineering Maintenance";
+	req_access = list(10)
 	},
-/obj/structure/curtain/open/shower,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/cafe,
-/area/liberty/bonfire/vectorrooms)
+/turf/simulated/floor/tiled/dark,
+/area/liberty/hallway/surface/section1)
 "pKT" = (
 /obj/machinery/porta_turret/prepper,
 /obj/machinery/light/small{
@@ -69571,11 +67681,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/liberty/engineering/atmos/storage)
-"pRn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/liberty/bonfire/vectorrooms)
 "pRr" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -69633,19 +67738,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/liberty/rnd/lab)
-"pSb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "pSd" = (
 /turf/simulated/floor/plating/under,
 /area/liberty/dungeon/outside/burned_outpost)
@@ -69810,12 +67902,15 @@
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/liberty/hallway/surface/section1)
 "pTB" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/spline/fancy{
 	dir = 10
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/bioreactor)
+/area/liberty/hallway/surface/section1)
 "pTH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -70507,7 +68602,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/bioreactor)
+/area/liberty/hallway/surface/section1)
 "qbI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/green{
@@ -70866,18 +68961,6 @@
 /obj/effect/window_lwall_spawn/smartspawnplasma,
 /turf/simulated/floor/plating/under,
 /area/liberty/engineering/atmos)
-"qgm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/vectorrooms)
 "qgu" = (
 /obj/structure/barricade,
 /obj/structure/boulder,
@@ -71029,9 +69112,6 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/turret_protected/ai_upload)
-"qhR" = (
-/turf/simulated/mineral,
-/area/liberty/bonfire/stronghold)
 "qhS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -71181,13 +69261,6 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/liberty/command/gmaster)
-"qjr" = (
-/obj/machinery/alarm{
-	pixel_y = 32
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "qjw" = (
 /obj/structure/bed/chair,
 /obj/effect/decal/cleanable/dirt,
@@ -71220,12 +69293,10 @@
 /turf/simulated/floor/industrial/bricks,
 /area/liberty/maintenance/undergroundfloor3north)
 "qjJ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/craftingstation,
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/liberty/engineering/atmos/storage)
 "qjN" = (
 /obj/random/scrap/sparse_even/low_chance,
 /obj/random/structures/low_chance,
@@ -71594,11 +69665,6 @@
 /obj/effect/floor_decal/industrial_plant/steel_grate_warning,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/liberty/maintenance/undergroundfloor3north)
-"qof" = (
-/obj/effect/floor_decal/spline/fancy,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/bioreactor)
 "qoj" = (
 /obj/effect/window_lwall_spawn/reinforced/polarized{
 	id = "WO"
@@ -71931,17 +69997,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/liberty/security/mess_hall)
-"qsX" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#0892d0"
-	},
-/obj/effect/floor_decal/spline/fancy{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/storage)
 "qte" = (
 /obj/item/trash/plate,
 /turf/simulated/floor/rock,
@@ -71971,14 +70026,6 @@
 	},
 /turf/simulated/floor/rock/manmade/road,
 /area/liberty/outside/range)
-"qtp" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/window_lwall_spawn/reinforced,
-/turf/simulated/floor/plating,
-/area/liberty/bonfire/stronghold)
 "qtr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -73287,16 +71334,6 @@
 	},
 /turf/simulated/floor/wood/wild1,
 /area/liberty/crew_quarters/dorm3)
-"qIf" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
-	},
-/obj/structure/mirror{
-	pixel_x = 28
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/vectorrooms)
 "qIg" = (
 /obj/effect/floor_decal/industrial/stand_clear/red{
 	dir = 1
@@ -73392,10 +71429,6 @@
 /turf/simulated/floor/rock,
 /area/liberty/maintenance/northcave)
 "qIR" = (
-/obj/machinery/door/airlock/mining{
-	name = "Fontaine Prep";
-	req_access = list(78)
-	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -73585,9 +71618,6 @@
 /obj/random/traps/low_chance,
 /turf/simulated/floor/plating/under,
 /area/liberty/maintenance/maint_merc)
-"qLo" = (
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/liberty/pros/shuttle)
 "qLs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -73896,23 +71926,17 @@
 /turf/simulated/floor/tiled/steel,
 /area/liberty/quartermaster/office)
 "qOU" = (
-/obj/machinery/door/bonfire{
-	name = "Storage"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/maintenance_common{
-	req_access = list(12)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/junction{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/storage)
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/liberty/hallway/surface/section1)
 "qOW" = (
 /obj/structure/multiz/stairs/enter/bottom{
 	dir = 8
@@ -73988,10 +72012,6 @@
 /obj/machinery/camera/network/command,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/liberty/command/meeting_room)
-"qPJ" = (
-/obj/machinery/washing_machine,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/vectorrooms)
 "qPP" = (
 /obj/effect/floor_decal/industrial/danger,
 /obj/structure/window/reinforced,
@@ -74086,13 +72106,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/undergroundfloor1north)
-"qRk" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/storage)
 "qRq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -74930,20 +72943,6 @@
 /obj/landmark/join/start/scientist,
 /turf/simulated/floor/tiled/dark,
 /area/liberty/rnd/research)
-"rbu" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/storage)
 "rby" = (
 /obj/machinery/disposal,
 /obj/effect/floor_decal/industrial/box/red,
@@ -74962,17 +72961,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/green_large_slates,
 /area/liberty/maintenance/undergroundfloor2north)
-"rbM" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "rbS" = (
 /obj/structure/plushie/drone,
 /turf/simulated/wall/r_wall,
@@ -75119,22 +73107,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/spline/fancy,
 /turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/bioreactor)
-"reg" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/airlock/maintenance_common{
-	req_access = list(12)
-	},
-/turf/simulated/floor/wood,
-/area/liberty/bonfire/vectorrooms)
+/area/liberty/hallway/surface/section1)
 "ren" = (
 /obj/effect/window_lwall_spawn/reinforced/polarized{
 	id = "CSO"
@@ -75471,10 +73444,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/liberty/quartermaster/vault)
-"rhK" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/vectorrooms)
 "rhT" = (
 /obj/structure/table/steel,
 /obj/random/lowkeyrandom/low_chance,
@@ -76359,16 +74328,6 @@
 /obj/random/cluster/roaches/beacon,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/liberty/maintenance/undergroundfloor3north)
-"rtw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "rtB" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -76390,18 +74349,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/oldarmory)
-"rtE" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "rtF" = (
 /obj/random/scrap/sparse_weighted,
 /obj/effect/decal/cleanable/dirt,
@@ -77019,18 +74966,6 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/maint_merc)
-"rzR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/storage)
 "rzS" = (
 /obj/effect/floor_decal/industrial_plant/steel_grate_warning,
 /turf/simulated/floor/industrial/grey_slates,
@@ -77335,13 +75270,6 @@
 	name = "murky water"
 	},
 /area/liberty/maintenance/undergroundfloor3south)
-"rDK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/spline/fancy{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "rDO" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -78019,13 +75947,6 @@
 /obj/structure/boulder,
 /turf/simulated/floor/plating/under,
 /area/liberty/maintenance/undergroundfloor3north)
-"rOb" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/disposal,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/vectorrooms)
 "rOc" = (
 /obj/structure/window/reinforced/crescent{
 	dir = 4
@@ -78130,12 +76051,10 @@
 /turf/simulated/floor/rock/manmade/road,
 /area/liberty/outside/forest)
 "rOO" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/medical/splint/improvised,
 /turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/vectorrooms)
+/area/liberty/maintenance/undergroundfloor1east)
 "rOW" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/cell/medium,
@@ -78167,7 +76086,7 @@
 	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
-/area/liberty/bonfire/bioreactor)
+/area/liberty/hallway/surface/section1)
 "rPz" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
@@ -78252,10 +76171,6 @@
 "rQM" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/mining{
-	name = "Fontaine Prep";
-	req_access = list(78)
-	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -78736,15 +76651,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/liberty/maintenance/undergroundfloor1east)
-"rWJ" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/storage)
 "rWO" = (
 /obj/structure/bed/chair/office/light{
 	dir = 4;
@@ -79316,16 +77222,6 @@
 	},
 /turf/simulated/floor/wood/wild1,
 /area/liberty/maintenance/undergroundfloor1east)
-"scx" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/obj/effect/floor_decal/industrial/warningred,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "scC" = (
 /obj/structure/bed/chair/sofa/teal/corner{
 	dir = 1
@@ -79932,19 +77828,6 @@
 /obj/structure/flora/ausbushes/grassybush,
 /turf/simulated/floor/asteroid/grass,
 /area/liberty/maintenance/undergroundfloor1oldgarden)
-"siG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance_common{
-	req_access = list(12)
-	},
-/turf/simulated/floor/plating,
-/area/liberty/bonfire/bioreactor)
 "siH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/alarm{
@@ -80621,20 +78504,6 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/plating/under,
 /area/liberty/maintenance/undergroundfloor2south)
-"spW" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "spX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -80696,15 +78565,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/liberty/maintenance/undergroundfloor1east)
 "sre" = (
-/obj/machinery/camera/network/custodians,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/storage)
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/liberty/hallway/surface/section1)
 "srf" = (
 /obj/item/storage/deferred/crate/uniform_light,
 /obj/effect/decal/cleanable/dirt,
@@ -80896,19 +78763,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild3,
 /area/liberty/crew_quarters)
-"stC" = (
-/obj/structure/disposalpipe/junction{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/vectorrooms)
 "stE" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -81102,16 +78956,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/undergroundfloor1south)
-"swr" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "swE" = (
 /obj/structure/sign/warning/nosmoking/small{
 	pixel_x = -25
@@ -81954,20 +79798,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/liberty/command/swo/quarters)
-"sFa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/floor_decal/spline/fancy{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/vectorrooms)
 "sFd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -82752,13 +80582,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/liberty/maintenance/undergroundfloor1east)
-"sNx" = (
-/obj/effect/floor_decal/spline/fancy{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/bioreactor)
 "sNB" = (
 /obj/structure/table/woodentable,
 /obj/random/junkfood/low_chance,
@@ -82831,7 +80654,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/under,
-/area/liberty/bonfire/bioreactor)
+/area/liberty/hallway/surface/section1)
 "sOy" = (
 /obj/random/closet/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -83050,7 +80873,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/bioreactor)
+/area/liberty/hallway/surface/section1)
 "sRV" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
@@ -83134,17 +80957,6 @@
 	},
 /turf/simulated/floor/wood/wild1,
 /area/liberty/crew_quarters/dorm3)
-"sSx" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/hallway/surface/section1)
 "sSz" = (
 /obj/structure/kitchenspike,
 /obj/machinery/camera/network/research{
@@ -83584,10 +81396,6 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/asteroid/grass,
 /area/liberty/hallway/side/f2section1)
-"sYa" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/storage)
 "sYf" = (
 /turf/simulated/wall/r_wall,
 /area/liberty/maintenance/undergroundfloor2west)
@@ -83918,13 +81726,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/undergroundfloor1south)
-"tcC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "tcI" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -83961,14 +81762,6 @@
 	temperature = 80
 	},
 /area/liberty/rnd/server)
-"tcU" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating/under,
-/area/liberty/bonfire/storage)
 "tcV" = (
 /obj/structure/bed/chair/office/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -84049,7 +81842,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/bioreactor)
+/area/liberty/hallway/surface/section1)
 "tdO" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -84224,7 +82017,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/bioreactor)
+/area/liberty/hallway/surface/section1)
 "tfm" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -84302,22 +82095,6 @@
 /obj/item/remains/human,
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/maint_merc)
-"tgI" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/vectorrooms)
 "tgT" = (
 /obj/machinery/light_switch{
 	pixel_y = 32
@@ -84947,18 +82724,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/undergroundfloor2east)
-"toS" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/spline/fancy{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/storage)
 "toX" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -85006,12 +82771,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/liberty/maintenance/undergroundfloor2north)
-"tpI" = (
-/obj/effect/floor_decal/spline/fancy{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/vectorrooms)
 "tpJ" = (
 /obj/random/scrap/dense_weighted/low_chance,
 /turf/simulated/floor/plating/under,
@@ -85103,14 +82862,6 @@
 	},
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/liberty/medical/sleeper)
-"tqt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/spline/fancy/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/bioreactor)
 "tqu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/chair{
@@ -85250,27 +83001,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/liberty/security/prison)
-"trR" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "trV" = (
 /obj/structure/table/rack/shelf,
 /obj/random/handmade_tool/low_chance,
@@ -85286,16 +83016,6 @@
 	icon_state = "8,23"
 	},
 /area/shuttle/rocinante_shuttle_area)
-"trZ" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/bioreactor)
 "tsb" = (
 /obj/effect/floor_decal/industrial/loading/white{
 	dir = 1
@@ -85455,9 +83175,6 @@
 /obj/machinery/camera/network/command,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/liberty/command/captain/quarters)
-"ttZ" = (
-/turf/simulated/wall/r_wall,
-/area/liberty/bonfire/bioreactor)
 "tuc" = (
 /obj/structure/shuttle_part/science{
 	icon_state = "0,6"
@@ -85767,19 +83484,6 @@
 /obj/machinery/meter,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/liberty/engineering/atmos)
-"txN" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/airlock/maintenance_common{
-	req_access = list(12)
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/vectorrooms)
 "txQ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
@@ -85812,18 +83516,6 @@
 /obj/effect/damagedfloor/rust,
 /turf/simulated/floor/plating/under,
 /area/liberty/maintenance/undergroundfloor3south)
-"tyk" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance_common{
-	req_access = list(12)
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/storage)
 "tym" = (
 /obj/structure/bed/chair/comfy/brown{
 	dir = 4
@@ -86052,29 +83744,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/undergroundfloor3east)
-"tBR" = (
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/liberty/pros/shuttle)
 "tCb" = (
 /obj/effect/decal/cleanable/dirt/snow,
 /obj/random/cluster/termite_no_despawn/low_chance,
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/undergroundfloor3west)
-"tCt" = (
-/obj/machinery/power/smes/buildable{
-	RCon_tag = "Substation - Custodian";
-	charge = 5e+006;
-	input_attempt = 1;
-	input_level = 125000;
-	output_attempt = 1;
-	output_level = 100000
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/liberty/bonfire/storage)
 "tCw" = (
 /obj/structure/table/standard,
 /obj/effect/decal/cleanable/dirt,
@@ -86617,29 +84291,12 @@
 /obj/random/contraband/low_chance,
 /turf/simulated/floor/tiled/white,
 /area/liberty/maintenance/undergroundfloor2north)
-"tHv" = (
-/obj/machinery/power/torchbearer,
-/turf/simulated/floor/tiled/white/brown_perforated,
-/area/liberty/hallway/surface/section1)
 "tHH" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/command/panic_room)
-"tHU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/vectorrooms)
 "tHX" = (
 /obj/random/mob/termite_no_despawn,
 /turf/simulated/floor/beach/water/jungledeep{
@@ -86721,12 +84378,6 @@
 /obj/random/traps/low_chance,
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/oldmining)
-"tJm" = (
-/obj/structure/bed,
-/obj/item/bedsheet/mime,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/liberty/bonfire/vectorrooms)
 "tJo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -87125,9 +84776,6 @@
 /obj/machinery/gym/robustness,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/liberty/crew_quarters/fitness)
-"tNr" = (
-/turf/unsimulated/mineral,
-/area/liberty/outside/bcave)
 "tNs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -87531,19 +85179,6 @@
 	},
 /turf/simulated/floor/asteroid/dirt/mud,
 /area/liberty/maintenance/undergroundfloor3north)
-"tRZ" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/spline/fancy,
-/obj/effect/floor_decal/spline/fancy{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/storage)
 "tSe" = (
 /obj/structure/table/reinforced,
 /obj/machinery/microscope,
@@ -87988,11 +85623,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/undergroundfloor2west)
-"tYy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/vectorrooms)
 "tYC" = (
 /obj/structure/cable/green{
 	d2 = 4;
@@ -88103,12 +85733,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/liberty/medical/psych)
-"tZw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "tZD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera/network/colony_underground{
@@ -88283,7 +85907,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
-/area/liberty/bonfire/bioreactor)
+/area/liberty/hallway/surface/section1)
 "ucf" = (
 /obj/random/scrap/dense_weighted/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -88618,17 +86242,6 @@
 	},
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/liberty/hallway/surface/section1)
-"ufE" = (
-/obj/machinery/power/terminal{
-	dir = 8
-	},
-/obj/structure/cable/cyan{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/storage)
 "ufJ" = (
 /obj/machinery/door/airlock{
 	name = "Bathroom"
@@ -88814,12 +86427,6 @@
 /obj/item/oddity/ls/puzzlebox,
 /turf/simulated/floor/industrial/ornate,
 /area/liberty/maintenance/bank)
-"uhK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "uhM" = (
 /obj/machinery/space_heater,
 /obj/structure/sign/painting/paintingsunset{
@@ -89327,10 +86934,6 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/liberty/engineering/engine_room)
-"unb" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/storage)
 "uni" = (
 /obj/effect/floor_decal/spline/plain,
 /obj/effect/decal/cleanable/dirt,
@@ -89481,9 +87084,6 @@
 	},
 /turf/simulated/floor/tiled/dark/panels,
 /area/liberty/pros/shuttle)
-"upq" = (
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/liberty/pros/shuttle)
 "upt" = (
 /obj/machinery/mineral/stacking_unit_console{
 	pixel_x = -28
@@ -89592,13 +87192,6 @@
 	},
 /turf/simulated/floor/tiled/steel/bar_dance,
 /area/liberty/maintenance/sunkenclub)
-"uqB" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "uqL" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4;
@@ -89873,11 +87466,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/liberty/hallway/surface/section1)
-"utS" = (
-/obj/machinery/door/firedoor,
-/obj/effect/window_lwall_spawn/smartspawn,
-/turf/simulated/floor/plating,
-/area/liberty/bonfire/vectorrooms)
 "utT" = (
 /obj/machinery/computer/mecha,
 /obj/structure/sign/warning/nosmoking/small{
@@ -90416,13 +88004,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/liberty/outside/inside_colony)
-"uzU" = (
-/obj/machinery/recharge_station,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/vectorrooms)
 "uzX" = (
 /obj/item/storage/firstaid,
 /obj/item/reagent_containers/syringe/drugs_recreational,
@@ -90603,12 +88184,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/turcarpet,
 /area/liberty/command/captain/quarters)
-"uCn" = (
-/obj/effect/floor_decal/spline/fancy{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/vectorrooms)
 "uCt" = (
 /obj/machinery/door/airlock/maintenance_rnd{
 	req_access = list(5)
@@ -90664,13 +88239,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/grey_slates,
 /area/liberty/maintenance/undergroundfloor1west)
-"uDx" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "uDy" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
@@ -91000,7 +88568,7 @@
 /obj/effect/floor_decal/spline/fancy,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/bioreactor)
+/area/liberty/hallway/surface/section1)
 "uIu" = (
 /obj/structure/railing/grey{
 	dir = 8;
@@ -91507,7 +89075,7 @@
 	},
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/bioreactor)
+/area/liberty/hallway/surface/section1)
 "uPU" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1
@@ -92204,16 +89772,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/liberty/engineering/atmos)
-"var" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/window_lwall_spawn/smartspawn,
-/turf/simulated/floor/plating,
-/area/colony)
 "vaD" = (
 /obj/item/stack/ore/gold/small,
 /turf/simulated/floor/beach/water/flooded,
@@ -92448,10 +90006,6 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/undergroundfloor1south)
-"vcS" = (
-/obj/random/cluster/tengolo,
-/turf/simulated/floor/rock,
-/area/liberty/outside/bcave)
 "vcT" = (
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/steel/bar_dance,
@@ -92642,15 +90196,6 @@
 /obj/structure/flora/small/snow/rock1,
 /turf/unsimulated/wall/snow,
 /area/liberty/outside/forest)
-"vfq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/bioreactor)
 "vfu" = (
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/plating/under,
@@ -93742,17 +91287,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/liberty/crew_quarters/hydroponics)
-"vrN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/spline/fancy,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/vectorrooms)
 "vrQ" = (
 /obj/machinery/holoposter{
 	pixel_x = 32
@@ -94250,18 +91784,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/liberty/pros/shuttle)
-"vwh" = (
-/obj/structure/decor_light/pyre,
-/turf/simulated/floor/tiled/white/brown_perforated,
-/area/liberty/hallway/surface/section1)
-"vwj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/spline/fancy/corner,
-/obj/effect/floor_decal/spline/fancy/corner{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "vwl" = (
 /obj/structure/table/standard,
 /obj/machinery/recharger,
@@ -94594,12 +92116,6 @@
 /obj/structure/barricade,
 /turf/simulated/floor/rock,
 /area/liberty/maintenance/undergroundfloor2east)
-"vBn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "vBx" = (
 /obj/structure/table/bar_special,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -95304,7 +92820,7 @@
 "vIk" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/liberty/bonfire/bioreactor)
+/area/liberty/hallway/surface/section1)
 "vIl" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -95503,18 +93019,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/grey_slates,
 /area/liberty/maintenance/undergroundfloor3north)
-"vKm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/spline/fancy{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "vKo" = (
 /obj/machinery/door/unpowered/simple/wood,
 /turf/simulated/floor/wood/wild1,
@@ -95691,15 +93195,6 @@
 /obj/structure/railing,
 /turf/simulated/floor/rock/manmade/road,
 /area/liberty/hallway/surface/section1)
-"vMZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "vNf" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/asteroid/grass/jungle,
@@ -95862,27 +93357,6 @@
 	},
 /turf/simulated/floor/tiled/dark/cargo,
 /area/liberty/quartermaster/miningdock)
-"vOx" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/light,
-/obj/structure/closet/wall_mounted/firecloset{
-	pixel_y = -32
-	},
-/obj/effect/floor_decal/industrial/warningred,
-/obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "vOF" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -95912,31 +93386,6 @@
 	name = "murky water"
 	},
 /area/liberty/maintenance/undergroundfloor3south)
-"vOZ" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "vPh" = (
 /obj/machinery/door/window/brigdoor/southright,
 /obj/effect/decal/cleanable/dirt,
@@ -96676,11 +94125,6 @@
 /obj/item/stack/ore/gold/small,
 /turf/simulated/floor/rock,
 /area/liberty/maintenance/northcave)
-"vYU" = (
-/obj/machinery/door/firedoor,
-/obj/effect/window_lwall_spawn/reinforced,
-/turf/simulated/floor/plating,
-/area/liberty/bonfire/stronghold)
 "vYW" = (
 /obj/random/scrap/dense_weighted/low_chance,
 /turf/simulated/floor/tiled/techmaint,
@@ -96787,21 +94231,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/liberty/medical/chemistry)
-"vZR" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -28
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/storage)
 "vZY" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 9
@@ -96899,13 +94328,6 @@
 	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/liberty/medical/genetics_cloning)
-"waD" = (
-/obj/structure/table/woodentable,
-/obj/effect/floor_decal/spline/fancy{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/vectorrooms)
 "waE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
@@ -97303,16 +94725,15 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/undergroundfloor2north)
 "wfd" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /obj/effect/floor_decal/spline/fancy{
 	dir = 5
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/bioreactor)
+/area/liberty/hallway/surface/section1)
 "wfp" = (
 /obj/random/junk/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -97479,10 +94900,6 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/maint_merc)
-"wgO" = (
-/obj/machinery/atmospherics/unary/vent_pump,
-/turf/simulated/wall/r_wall,
-/area/liberty/bonfire/vectorrooms)
 "wgR" = (
 /obj/structure/kitchenspike,
 /obj/effect/decal/cleanable/blood,
@@ -97576,13 +94993,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/asteroid/grass,
 /area/liberty/rnd/xenoflora)
-"whD" = (
-/obj/effect/floor_decal/spline/fancy{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/storage)
 "whL" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -97736,11 +95146,6 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/industrial/fancy_slates,
 /area/liberty/maintenance/undergroundfloor3north)
-"wjr" = (
-/obj/machinery/atmospherics/unary/vent_pump,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/liberty/bonfire/vectorrooms)
 "wjH" = (
 /obj/structure/closet/wall_mounted/emcloset/escape_pods{
 	dir = 1;
@@ -98590,19 +95995,13 @@
 /turf/simulated/wall/r_wall,
 /area/liberty/quartermaster/miningdock)
 "wtE" = (
-/obj/effect/floor_decal/spline/fancy,
-/obj/effect/floor_decal/industrial/warningred,
-/obj/structure/closet/wall_mounted/firecloset{
-	pixel_y = -32
-	},
-/obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/box/red/corners{
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/bioreactor)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/liberty/hallway/surface/section1)
 "wtK" = (
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/liberty/security/range)
@@ -98790,12 +96189,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/liberty/crew_quarters/barbackroom)
-"wvT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "wvV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/standard,
@@ -98913,19 +96306,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_panels,
 /area/liberty/maintenance/oldarmory)
-"wxA" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/effect/floor_decal/spline/fancy{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/storage)
 "wxW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -100138,20 +97518,13 @@
 /turf/simulated/floor/rock/alt,
 /area/liberty/maintenance/maint_merc)
 "wLb" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/disposalpipe/segment{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance_common{
-	req_access = list(12)
-	},
-/turf/simulated/floor/plating,
-/area/liberty/bonfire/stronghold)
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/liberty/hallway/surface/section1)
 "wLe" = (
 /obj/structure/table/woodentable,
 /obj/item/reagent_containers/food/snacks/meat/corgi,
@@ -100252,7 +97625,7 @@
 	operating = 1
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/liberty/bonfire/bioreactor)
+/area/liberty/hallway/surface/section1)
 "wMp" = (
 /obj/effect/decal/cleanable/cobweb2{
 	icon_state = "cobweb1";
@@ -100324,17 +97697,6 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/liberty/medical/genetics)
-"wNa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/vectorrooms)
 "wNd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/scrap/dense_weighted/low_chance,
@@ -100643,12 +98005,6 @@
 	dir = 4
 	},
 /area/liberty/crew_quarters/hotsprings)
-"wQl" = (
-/obj/machinery/vending/fitness{
-	shut_up = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "wQp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -100803,17 +98159,6 @@
 /obj/item/remains/human,
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/maint_merc)
-"wSg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/invislight/outside,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/liberty/hallway/surface/section1)
 "wSh" = (
 /obj/machinery/vending/cola,
 /obj/structure/window/reinforced{
@@ -100868,19 +98213,6 @@
 /obj/machinery/door/firedoor/multi_tile,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/liberty/security/prison)
-"wSR" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 32
-	},
-/obj/effect/floor_decal/spline/fancy{
-	dir = 6
-	},
-/obj/structure/table/woodentable,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/bioreactor)
 "wSZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -100951,11 +98283,6 @@
 /obj/structure/flora/small/rock1,
 /turf/simulated/floor/asteroid/grass/jungle,
 /area/liberty/hallway/side/f2section1)
-"wTS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/bioreactor)
 "wTT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/chair/custom/wood{
@@ -102212,27 +99539,6 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/liberty/hallway/surface/section1)
-"xjh" = (
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/effect/floor_decal/spline/fancy/corner{
-	dir = 8
-	},
-/obj/effect/floor_decal/spline/fancy/corner{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/storage)
 "xjn" = (
 /obj/random/oddity_guns,
 /turf/simulated/floor/rock,
@@ -102264,13 +99570,6 @@
 /obj/item/towel,
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/quartermaster/fightclub)
-"xjC" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/storage)
 "xjD" = (
 /turf/simulated/mineral,
 /area/liberty/dungeon/outside/campground)
@@ -102341,11 +99640,6 @@
 /obj/machinery/space_heater,
 /turf/simulated/floor/industrial/bricks,
 /area/liberty/maintenance/undergroundfloor1south)
-"xkW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating/under,
-/area/liberty/bonfire/vectorrooms)
 "xkZ" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -102366,26 +99660,6 @@
 /obj/structure/multiz/stairs/enter/bottom,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/liberty/engineering/engine_room)
-"xlm" = (
-/obj/machinery/door/bonfire{
-	name = "Custodians Stronghold"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/maintenance_common{
-	req_access = list(12)
-	},
-/turf/simulated/floor/plating,
-/area/liberty/bonfire/stronghold)
 "xls" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/green{
@@ -102484,18 +99758,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/liberty/security/interrogation)
-"xmF" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/effect/floor_decal/spline/fancy{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/storage)
 "xmO" = (
 /obj/structure/bed/chair/sofa/black/right,
 /obj/structure/window/reinforced{
@@ -102943,11 +100205,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/liberty/security/armory)
-"xrO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/spline/fancy,
-/turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/vectorrooms)
 "xrU" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
@@ -103844,16 +101101,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/liberty/security/sechall)
-"xCo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/liberty/hallway/surface/section1)
 "xCz" = (
 /obj/machinery/door/airlock/maintenance_rnd{
 	req_access = list(5)
@@ -103952,23 +101199,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/white_large_slates,
 /area/liberty/maintenance/undergroundfloor1west)
-"xDl" = (
-/obj/random/furniture/pottedplant,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
-"xDp" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/vectorrooms)
 "xDv" = (
 /obj/structure/bed/chair/comfy/blue{
 	dir = 1
@@ -104107,13 +101337,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/security/main)
-"xEB" = (
-/obj/structure/noticeboard/church{
-	pixel_y = 32
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/bioreactor)
 "xEE" = (
 /obj/structure/table/rack,
 /obj/item/storage/backpack/industrial{
@@ -104131,19 +101354,6 @@
 /obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/undergroundfloor1east)
-"xEL" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "xEX" = (
 /turf/simulated/floor/rock,
 /area/liberty/maintenance/cavenightmare)
@@ -104446,16 +101656,6 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/liberty/command/captain/quarters)
-"xJj" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/spline/fancy{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "xJm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/green{
@@ -104859,10 +102059,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/liberty/quartermaster/office)
-"xNP" = (
-/obj/effect/floor_decal/industrial/box/white,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/bioreactor)
 "xNQ" = (
 /obj/structure/sign/warning/nosmoking/small,
 /turf/simulated/wall/r_wall,
@@ -105741,20 +102937,6 @@
 /obj/structure/flora/snowgrass/rockandgrass,
 /turf/simulated/floor/snow,
 /area/liberty/maintenance/undergroundfloor3north)
-"xXE" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/stronghold)
 "xXJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -105763,12 +102945,6 @@
 /obj/random/mob/roaches,
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/undergroundfloor3east)
-"xXO" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/vectorrooms)
 "xXX" = (
 /obj/structure/railing{
 	dir = 8
@@ -105785,8 +102961,8 @@
 "xYl" = (
 /obj/effect/floor_decal/industrial/outline,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/liberty/bonfire/bioreactor)
+/turf/simulated/wall/r_wall,
+/area/liberty/hallway/surface/section1)
 "xYp" = (
 /obj/structure/flora/snowgrass/vegetation,
 /turf/simulated/floor/snow,
@@ -106089,18 +103265,6 @@
 /obj/structure/flora/grass/brown,
 /turf/unsimulated/wall/snow,
 /area/liberty/outside/forest)
-"yaY" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance_common{
-	req_access = list(12)
-	},
-/turf/simulated/floor/plating,
-/area/liberty/bonfire/bioreactor)
 "yaZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed,
@@ -106115,8 +103279,7 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 4
 	},
-/obj/effect/floor_decal/industrial/road/curvebig4,
-/obj/effect/floor_decal/industrial/warningwhite,
+/obj/effect/floor_decal/industrial/road/curve3,
 /turf/simulated/floor/rock/manmade/road,
 /area/liberty/outside/inside_colony)
 "ybf" = (
@@ -106394,9 +103557,6 @@
 /obj/random/scrap/sparse_even,
 /turf/simulated/floor/rock/alt,
 /area/liberty/maintenance/maint_merc)
-"yfl" = (
-/turf/simulated/floor/tiled/steel/gray_platform,
-/area/liberty/crew_quarters/janitor)
 "yfm" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
@@ -106506,10 +103666,12 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/undergroundfloor2north)
 "yfY" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/vectorrooms)
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/liberty/hallway/surface/section1)
 "yge" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -106632,13 +103794,16 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/spline/fancy{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled/dark/golden,
-/area/liberty/bonfire/bioreactor)
+/area/liberty/hallway/surface/section1)
 "yhc" = (
 /obj/structure/flora/snowgrass/rockandgrass,
 /turf/simulated/floor/snow,
@@ -106740,21 +103905,6 @@
 "yib" = (
 /turf/simulated/wall/r_wall,
 /area/liberty/security/tactical)
-"yif" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/bonfire/bioreactor)
 "yij" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 8
@@ -106963,9 +104113,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/liberty/maintenance/undergroundfloor1east)
-"yko" = (
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/liberty/pros/shuttle)
 "ykx" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -107019,13 +104166,6 @@
 	},
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/liberty/rnd/robotics)
-"ykU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/liberty/bonfire/vectorrooms)
 "ykV" = (
 /obj/random/mob/roaches/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -115541,10 +112681,10 @@ tuH
 den
 let
 mbD
-yfl
+sQd
 wtN
-yfl
-yfl
+sQd
+sQd
 sQd
 qzz
 tuH
@@ -115945,10 +113085,10 @@ tuH
 wgX
 let
 mbD
-yfl
+sQd
 dfi
-yfl
-yfl
+sQd
+sQd
 kmV
 kro
 tuH
@@ -116147,9 +113287,9 @@ tuH
 pUn
 kYB
 cnE
-yfl
+sQd
 dfi
-yfl
+sQd
 adb
 ocW
 ocW
@@ -134326,7 +131466,7 @@ oTF
 voe
 voe
 voe
-gob
+oKp
 iAR
 qVZ
 uKZ
@@ -134727,7 +131867,7 @@ mMp
 tQX
 dBV
 nNc
-oKp
+qjJ
 bQQ
 oKp
 oKp
@@ -134933,7 +132073,7 @@ hoa
 hoa
 cqr
 oKp
-osj
+ofg
 qVZ
 uKZ
 ozS
@@ -188708,21 +185848,21 @@ uKZ
 uKZ
 uKZ
 uKZ
-tNr
-tNr
-bbh
-bbh
-bbh
-bbh
-tNr
-tNr
-tNr
-tNr
-tNr
-tNr
-tNr
-tNr
-tNr
+uKZ
+uKZ
+omv
+omv
+omv
+omv
+uKZ
+uKZ
+uKZ
+uKZ
+uKZ
+uKZ
+uKZ
+uKZ
+uKZ
 uKZ
 uKZ
 omv
@@ -188910,21 +186050,21 @@ omv
 uKZ
 uKZ
 uKZ
-tNr
-tNr
-bbh
-rwX
-dpF
-bbh
-tNr
-tNr
-tNr
-tNr
-tNr
-tNr
-tNr
-tNr
-tNr
+uKZ
+uKZ
+omv
+omv
+omv
+omv
+uKZ
+uKZ
+uKZ
+uKZ
+uKZ
+uKZ
+uKZ
+uKZ
+uKZ
 uKZ
 uKZ
 omv
@@ -189112,18 +186252,18 @@ omv
 omv
 omv
 omv
-tNr
-tNr
-bbh
-dpF
-dpF
-bbh
-bbh
-bbh
-tNr
-tNr
-tNr
-tNr
+uKZ
+uKZ
+omv
+omv
+omv
+omv
+omv
+omv
+uKZ
+uKZ
+uKZ
+uKZ
 bbh
 bbh
 bbh
@@ -189314,17 +186454,17 @@ omv
 omv
 omv
 omv
-bbh
-bbh
-bbh
-rwX
-dpF
-dpF
-rwX
-bbh
-bbh
-tNr
-bbh
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+uKZ
+uKZ
 bbh
 bbh
 rwX
@@ -189519,14 +186659,14 @@ omv
 omv
 omv
 omv
-bbh
-epC
-dpF
-dpF
-rwX
-bbh
-bbh
-bbh
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+uKZ
 rwX
 dpF
 dpF
@@ -189675,7 +186815,7 @@ omv
 omv
 omv
 rOo
-upq
+rTA
 wVf
 aNd
 mqZ
@@ -189721,15 +186861,15 @@ omv
 omv
 omv
 omv
-bbh
-dpF
-dpF
-vNH
-dpF
-bbh
-bbh
-rwX
-dpF
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+ecH
+uKZ
 vNH
 dpF
 dpF
@@ -189877,35 +187017,35 @@ omv
 omv
 omv
 rOo
-upq
+rTA
 uHO
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
 rTA
 mXG
 aPB
@@ -189923,19 +187063,19 @@ omv
 omv
 omv
 omv
-bbh
-rwX
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+uKZ
 dpF
 epC
 dpF
-rwX
-bbh
 dpF
-dpF
-dpF
-epC
-dpF
-epC
 dpF
 bbh
 bbh
@@ -190079,35 +187219,35 @@ omv
 omv
 omv
 rOo
-upq
+rTA
 uHO
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
 mXG
 rOo
 omv
@@ -190124,16 +187264,16 @@ omv
 omv
 omv
 omv
-bbh
-bbh
-rwX
-dpF
-dpF
-dpF
-vcS
-dpF
-epC
-dpF
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+uKZ
 dpF
 dpF
 dpF
@@ -190175,6 +187315,7 @@ cqw
 cqw
 vZK
 vZK
+kin
 "}
 (12,1,3) = {"
 uKZ
@@ -190280,36 +187421,36 @@ omv
 omv
 omv
 odm
-upq
+rTA
 nIe
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-ffy
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
 bRK
 odm
 omv
@@ -190328,18 +187469,18 @@ omv
 omv
 omv
 omv
-bbh
-bbh
+omv
+omv
+omv
+omv
+omv
+omv
+uKZ
 dpF
-epC
-dpF
-vNH
 dpF
 dpF
 dpF
 dpF
-ojV
-epC
 dpF
 rwX
 bbh
@@ -190482,36 +187623,36 @@ omv
 omv
 omv
 rOo
-upq
+rTA
 wVB
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-yko
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
 lYH
 aPB
 rQC
@@ -190530,14 +187671,14 @@ omv
 omv
 omv
 omv
-bbh
-dpF
-vNH
-dpF
-epC
-dpF
-dpF
-wEQ
+omv
+omv
+omv
+omv
+omv
+omv
+uKZ
+uKZ
 dMf
 bbh
 bbh
@@ -190684,36 +187825,36 @@ omv
 omv
 omv
 rOo
-upq
+rTA
 uHO
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-qLo
-tBR
-fGF
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
 mXG
 aPB
 pFr
@@ -190731,16 +187872,16 @@ omv
 omv
 omv
 omv
-bbh
-bbh
-dpF
-epC
-ojV
-dpF
-bbh
-dpF
 omv
 omv
+omv
+omv
+omv
+omv
+omv
+omv
+uKZ
+uKZ
 bbh
 bbh
 vNH
@@ -190886,36 +188027,36 @@ omv
 omv
 omv
 odm
-upq
+rTA
 uHO
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
 mXG
 aPB
 rQC
@@ -190932,17 +188073,17 @@ omv
 omv
 omv
 omv
-bbh
-bbh
-rwX
-dpF
-epC
-dpF
-bbh
 omv
 omv
 omv
 omv
+omv
+omv
+omv
+omv
+omv
+omv
+uKZ
 bbh
 bbh
 rwX
@@ -191088,36 +188229,36 @@ eRh
 eRh
 lFy
 rOo
-upq
+rTA
 uHO
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
 mXG
 kdl
 rQC
@@ -191134,17 +188275,17 @@ omv
 omv
 omv
 omv
-bbh
-dpF
-bbh
-epC
-dpF
-bbh
-bbh
 omv
 omv
 omv
 omv
+omv
+omv
+omv
+omv
+omv
+omv
+uKZ
 bbh
 bbh
 bbh
@@ -191290,36 +188431,36 @@ mza
 mza
 lFy
 rOo
-upq
+rTA
 uHO
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
 mXG
 aPB
 oQS
@@ -191336,17 +188477,17 @@ omv
 omv
 omv
 omv
-bbh
-bbh
-rwX
-dpF
-bbh
-bbh
-bbh
 omv
 omv
 omv
 omv
+omv
+omv
+omv
+omv
+omv
+omv
+uKZ
 cqw
 cqw
 cqw
@@ -191494,34 +188635,34 @@ lFy
 wkf
 uPU
 uHO
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
 mXG
 rOo
 omv
@@ -191548,7 +188689,7 @@ omv
 omv
 omv
 omv
-omv
+uKZ
 vZK
 vZK
 vZK
@@ -191694,36 +188835,36 @@ tbV
 mza
 lFy
 ygN
-upq
+rTA
 hHM
 cro
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
 lYH
 odm
 omv
@@ -191898,34 +189039,34 @@ lFy
 wCj
 gCr
 uHO
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
 mXG
 rOo
 omv
@@ -192098,36 +189239,36 @@ tbV
 mza
 lFy
 oHk
-upq
+rTA
 uHO
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
 mXG
 rOo
 omv
@@ -192300,36 +189441,36 @@ raJ
 mza
 lFy
 oHk
-upq
+rTA
 uHO
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
 mXG
 kdl
 cOr
@@ -192502,36 +189643,36 @@ tbV
 mza
 lFy
 oHk
-upq
+rTA
 uHO
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
 mXG
 aPB
 jAg
@@ -192704,36 +189845,36 @@ tbV
 mza
 lFy
 mQI
-upq
+rTA
 uHO
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
 mXG
 aPB
 rQC
@@ -192906,36 +190047,36 @@ tbV
 mza
 lFy
 oHk
-upq
+rTA
 wVB
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
 mXG
 aPB
 rQC
@@ -193108,36 +190249,36 @@ tbV
 vcL
 lFy
 oHk
-upq
+rTA
 nIe
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
 lYH
 aPB
 rQC
@@ -193310,36 +190451,36 @@ tbV
 mza
 lFy
 oHk
-upq
+rTA
 uHO
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
 bRK
 aPB
 fDb
@@ -193512,36 +190653,36 @@ gIi
 mza
 lFy
 mQI
-upq
+rTA
 uHO
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
-upq
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
+rTA
 mXG
 aPB
 rQC
@@ -193714,7 +190855,7 @@ tbV
 mza
 lFy
 cAF
-upq
+rTA
 mFU
 hLU
 mUi
@@ -199958,8 +197099,8 @@ dqC
 qTU
 dTl
 jHK
-vwh
-tHv
+vQa
+vQa
 nLs
 maI
 sQJ
@@ -202187,7 +199328,7 @@ vxC
 vxC
 mok
 vID
-ukl
+qOU
 rXO
 ukl
 ukl
@@ -202260,17 +199401,17 @@ rlB
 wgB
 wgB
 wgB
+uIi
 wgB
 wgB
-wgB
-wgB
+cuc
 wgB
 rlB
 wgB
 wgB
 wgB
 wgB
-cuc
+wgB
 wgB
 wgB
 wgB
@@ -202389,7 +199530,7 @@ rst
 rst
 rst
 mzq
-rst
+cdM
 pra
 rst
 rst
@@ -202463,16 +199604,16 @@ ouz
 ouz
 ouz
 ouz
-ouz
-ouz
-ouz
-ouz
-ouz
-ouz
-ouz
-ouz
 qec
 eCD
+wgB
+wgB
+wgB
+wgB
+wgB
+wgB
+wgB
+wgB
 wgB
 wgB
 wgB
@@ -202586,21 +199727,21 @@ cBj
 luq
 luq
 luq
-luq
-cBj
-luq
-luq
-luq
-luq
+mRu
+wtE
+khU
+khU
+khU
+wLb
 bOl
-luq
-luq
-iYg
+khU
+khU
+sre
 luq
 vXS
-auL
-iYg
-kxu
+luq
+yfY
+luq
 vXS
 luq
 fcp
@@ -202665,16 +199806,16 @@ hCL
 hCL
 hCL
 hCL
-hCL
-hCL
-hCL
-hCL
-hCL
-hCL
-hCL
-hCL
 rOH
 xFm
+wgB
+wgB
+rlB
+wgB
+wgB
+wgB
+wgB
+wgB
 wgB
 wgB
 wgB
@@ -202783,32 +199924,32 @@ sPV
 bye
 plb
 plb
-sPV
-sPV
-sPV
-sPV
-sPV
-sPV
-sPV
-sPV
-sPV
-sPV
-sPV
-sPV
-sPV
-vYU
-qtp
-sPV
-sPV
-mRu
-lfX
-oPQ
-sPV
-sPV
-cqx
-cqx
-sPV
-sPV
+jux
+jux
+jux
+jux
+fGB
+hPf
+jux
+jux
+pKR
+fGB
+fGB
+jux
+jux
+jux
+jux
+jux
+jux
+ceR
+jux
+ceR
+jux
+jux
+jux
+jux
+jux
+jux
 ufA
 rgr
 nJK
@@ -202867,16 +200008,16 @@ hCL
 hCL
 hCL
 hCL
-hCL
-hCL
-hCL
-hCL
-hCL
-hCL
-hCL
-hCL
 rOH
 eCD
+wgB
+gNC
+wgB
+wgB
+wgB
+wgB
+rtf
+wgB
 cvY
 wgB
 wgB
@@ -202986,31 +200127,31 @@ bOw
 lef
 lVQ
 kqN
-sPV
-qhR
-ttZ
+jvb
+omv
+jux
 sRU
 yhb
-yhb
+gOY
 mOS
-yhb
-yhb
+gOY
+gOY
 kbk
-ttZ
-ari
-haP
-vMZ
-nnD
-cWA
-kGI
-qjJ
-tZw
-gqC
-pAO
-lSv
-aMj
-mfH
-sPV
+jux
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+jux
 fFw
 rgr
 nJK
@@ -203069,16 +200210,16 @@ lkz
 lkz
 lkz
 lkz
-lkz
-lkz
-lkz
-lkz
-lkz
-lkz
-lkz
-lkz
 eEK
 ewK
+wgB
+wgB
+wgB
+wgB
+wgB
+wgB
+wgB
+wgB
 wgB
 wgB
 gpO
@@ -203188,9 +200329,9 @@ bOw
 lVQ
 vfD
 kqN
-sPV
-qhR
-ttZ
+jvb
+omv
+jux
 nPQ
 hVU
 hVU
@@ -203198,21 +200339,21 @@ ekK
 hVU
 ucc
 wfd
-frp
-fbw
-kGI
-mVB
-mfH
-mVB
-mVB
-jhX
-mfH
-mVB
-mVB
-mfH
-tZw
-kSm
-vYU
+jux
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+jux
 luq
 rgr
 nJK
@@ -203273,14 +200414,14 @@ wgB
 rlB
 wgB
 wgB
-wgB
-cvY
-wgB
-wgB
-wgB
-cvY
-wgB
 cuc
+cvY
+wgB
+wgB
+wgB
+cvY
+wgB
+wgB
 wgB
 rMe
 wgB
@@ -203391,8 +200532,8 @@ jvb
 jvb
 jvb
 jvb
-jvb
-ttZ
+omv
+jux
 aRu
 sOd
 iYM
@@ -203400,21 +200541,21 @@ wMm
 rPn
 jZR
 aXi
-ttZ
-pSb
-mfH
-mVB
-mVB
-mfH
-mfH
-jhX
-mfH
-mVB
-mVB
-mfH
-mVB
-nWX
-sPV
+jux
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+jux
 luq
 rgr
 cXI
@@ -203587,14 +200728,14 @@ dqC
 veD
 saN
 aRj
-sPV
-jvb
-beE
-tCt
-vZR
-dPR
-mrD
-ttZ
+jux
+omv
+omv
+omv
+omv
+omv
+omv
+jux
 ebk
 tdM
 uPS
@@ -203602,21 +200743,21 @@ nbo
 tfj
 qbD
 pTB
-ocL
-bXX
-mfH
-mVB
-mVB
-mVB
-mVB
-jhX
-mfH
-mVB
-mVB
-mfH
-mVB
-nWX
-vYU
+jux
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+jux
 jbn
 mtD
 pQP
@@ -203789,36 +200930,36 @@ dqC
 veD
 saN
 rgr
-sPV
-jvb
-cxb
-ufE
-ptb
-pgl
-mrD
-ttZ
-bne
+jux
+omv
+omv
+omv
+omv
+omv
+omv
+jux
+nnh
 hEk
 hEk
 vIk
-cuz
+pPu
 hEk
 uIr
-ttZ
-hRx
-ibr
-gVR
-gVR
-gVR
-gVR
-jdn
-mVB
-mVB
-mVB
-mfH
-llh
-scx
-sPV
+jux
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+jux
 knM
 hJI
 agT
@@ -203991,36 +201132,36 @@ dqC
 vSS
 oTb
 gTX
-sPV
-jvb
-kcb
-cxm
-ptb
-tcU
-nnh
-ttZ
+jux
+omv
+omv
+omv
+omv
+omv
+omv
+jux
 bne
 hEk
 hEk
 vIk
-cuz
+pPu
 hEk
 rdY
-lpM
-rtw
-mVB
-mfH
-mVB
-mVB
-mVB
-mVB
-mVB
-mVB
-mVB
-mfH
-mVB
-nWX
-vYU
+jux
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+jux
 ojp
 hJI
 euL
@@ -204193,36 +201334,36 @@ jux
 veD
 saN
 rgr
-sPV
-jvb
-sre
-nrl
-lQo
-kUp
-mrD
-ttZ
+jux
+omv
+omv
+omv
+omv
+omv
+omv
+jux
 dDR
-hEk
-hEk
+ceR
+ceR
 xYl
-cuz
-hEk
+jux
+ceR
 aKZ
-ttZ
-eLt
-mVB
-mfH
-mfH
-mVB
-mVB
-mfH
-mVB
-mVB
-mfH
-mVB
-mVB
-vBn
-sPV
+jux
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+jux
 cTd
 hJI
 fED
@@ -204395,36 +201536,36 @@ jux
 veD
 saN
 rgr
-sPV
-jvb
-nbu
-mad
-rbu
-rzR
-nQw
-gOY
-dPz
-pKJ
-trZ
-yif
-tqt
-dGm
-qof
-lpM
-eTS
-tcC
-mfH
-mVB
-mVB
-mVB
-mfH
-mVB
-mVB
-mfH
-mVB
-uhK
-hCQ
-vYU
+jux
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+jux
 ojp
 hJI
 odG
@@ -204597,36 +201738,36 @@ pdK
 ivl
 bcY
 cEA
-sPV
-jvb
-nrl
-nrl
-haR
-nrl
-nrl
-ttZ
-bhp
-cuz
-nBc
-nVD
-hEk
-hEk
-wtE
-ttZ
-pdE
-aOf
-chL
-wvT
-wvT
-wvT
-fZK
-wvT
-wvT
-fZK
-fyT
-uqB
-wQl
-sPV
+jux
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+jux
 ojp
 hJI
 bSa
@@ -204799,36 +201940,36 @@ jux
 cso
 saN
 aRj
-sPV
-jvb
-nrl
-pGV
-hQx
-xjC
-nrl
-ttZ
-hEk
-hEk
-hEk
-gMd
-wTS
-gix
-ePP
-ttZ
-sPV
-xlm
-sPV
-mVB
-mVB
-mVB
-mfH
-mVB
-mVB
-sPV
-sPV
-cBR
-sPV
-sPV
+jux
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+jux
 jPq
 hJI
 fED
@@ -205001,36 +202142,36 @@ jux
 veD
 saN
 iLm
-sPV
-jvb
-nrl
-nrl
-jAM
-nde
-nrl
-ttZ
-xEB
-hEk
-hEk
-hAG
-gch
-gWh
-nME
-ttZ
-kls
-azE
-sPV
-mVB
-mfH
-mfH
-mVB
-mfH
-mfH
-sPV
-mUK
-azE
-mfH
-sPV
+jux
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+jux
 qSP
 hJI
 odG
@@ -205203,36 +202344,36 @@ jux
 veD
 saN
 rgr
-sPV
-jvb
-jvb
-jvb
-tyk
-jvb
-jvb
-ttZ
-xNP
-hEk
-kYa
-vfq
-aZe
-sNx
-wSR
-ttZ
-dVX
-azE
-sPV
-hkb
-mVB
-mVB
-mVB
-mfH
-hkb
-sPV
-lWp
-azE
-mfH
-sPV
+jux
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+jux
 dTX
 hJI
 bSa
@@ -205405,36 +202546,36 @@ jux
 veD
 saN
 rgr
-sPV
-jvb
-nGq
-nGq
-tRZ
-nGq
-nGq
-ttZ
-ttZ
-adx
-ecH
-siG
-yaY
-ecH
-ttZ
-ttZ
-jPY
-azE
-sPV
-sPV
-sPV
-sPV
-sPV
-sPV
-sPV
-sPV
-pxa
-uDx
-kWq
-sPV
+jux
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+jux
 dTX
 hJI
 cpg
@@ -205607,37 +202748,37 @@ dqC
 veD
 saN
 rgr
-sPV
-jvb
-nGq
-nGq
-aPA
-glk
-mPm
-var
-vKm
-ehd
-oWI
-jQK
-xEL
-gAY
-eGJ
-olE
-aMW
-flI
-sPV
+jux
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
 usE
 usE
 usE
 usE
 usE
-usE
-sPV
-eHU
-kwY
-fZK
-pui
-chi
+omv
+omv
+omv
+omv
+jux
+dTX
 cIh
 vWL
 kVq
@@ -205809,36 +202950,36 @@ dqC
 veD
 saN
 rgr
-sPV
-jvb
-qsX
-whD
-xjh
-nxr
-jsd
-qOU
-lsd
-czH
-kin
-pBd
-hSS
-rtE
-swr
-rbM
-bhy
-vOx
-sPV
-hFu
+jux
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
 usE
 eSc
 jrv
 eSc
 usE
-sPV
-mfH
-mfH
-mfH
-sPV
+omv
+omv
+omv
+omv
+jux
 hJF
 jNf
 auy
@@ -206011,36 +203152,36 @@ dqC
 veD
 saN
 rgr
-sPV
-jvb
-nTx
-xmF
-cHO
-rWJ
-sYa
-jvb
-jot
-vwj
-bVH
-mfH
-mfH
-izg
-rDK
-bgs
-iws
-gYE
-sPV
-hFu
+jux
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
 usE
 eSc
 eSc
 eSc
 usE
-sPV
-mfH
-mfH
-mfH
-sPV
+omv
+omv
+omv
+omv
+jux
 rZG
 dBj
 kZc
@@ -206213,36 +203354,36 @@ dqC
 veD
 saN
 aRj
-sPV
-jvb
-unb
-aLz
-toS
-wxA
-dgW
-jvb
-jvb
-exD
-sPV
-sPV
-sPV
-sPV
-sPV
-sPV
-iIm
-gYE
-sPV
-hFu
+jux
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
 usE
 eSc
 eSc
 eSc
 usE
-sPV
-mfH
-hkb
-mfH
-sPV
+omv
+omv
+omv
+omv
+jux
 cTd
 cIq
 ogM
@@ -206415,36 +203556,36 @@ jiE
 veD
 saN
 sMP
-sPV
-jvb
-unb
-unb
-qRk
-unb
-unb
-jvb
-bjh
-pfw
-sPV
+jux
 omv
 omv
 omv
 omv
-sPV
-iIm
-gYE
-sPV
-hFu
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
 usE
 bOA
 guJ
 mkG
 usE
-sPV
-sPV
-sPV
-sPV
-sPV
+omv
+omv
+omv
+omv
+jux
 fBM
 cIq
 ckk
@@ -206617,25 +203758,25 @@ uys
 uZJ
 lPe
 syS
-sPV
-jvb
-jvb
-jvb
-jvb
-jvb
-jvb
-jvb
-jvb
-jvb
-sPV
+jux
 omv
 omv
 omv
 omv
-sPV
-iIm
-gYE
-sPV
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
 usE
 usE
 qcw
@@ -206703,9 +203844,9 @@ wgB
 nUD
 kfM
 kfM
-kfM
-kfM
-kfM
+wgB
+wgB
+wgB
 kfM
 kfM
 kfM
@@ -206817,11 +203958,9 @@ unv
 luq
 jiE
 veD
-saN
+ngd
 sMP
-sPV
-aOV
-aOV
+jux
 omv
 omv
 omv
@@ -206834,10 +203973,12 @@ omv
 omv
 omv
 omv
-sPV
-cjQ
-lKi
-sPV
+omv
+omv
+omv
+omv
+omv
+omv
 usE
 urU
 cIU
@@ -206905,12 +204046,12 @@ iiC
 kfM
 kfM
 kfM
-wgB
+kfM
+kfM
 kfM
 wgB
-wgB
-wgB
-wgB
+kfM
+kfM
 kfM
 kfM
 kfM
@@ -207019,11 +204160,9 @@ bzZ
 unw
 dqC
 veD
-saN
+ngd
 aRj
-sPV
-omv
-aOV
+jux
 omv
 omv
 omv
@@ -207036,10 +204175,12 @@ omv
 omv
 omv
 omv
-sPV
-iIm
-gYE
-sPV
+omv
+omv
+omv
+omv
+omv
+omv
 usE
 kwX
 vrM
@@ -207110,7 +204251,7 @@ kfM
 wgB
 wgB
 wgB
-wgB
+kfM
 kfM
 kfM
 kfM
@@ -207221,12 +204362,9 @@ bzZ
 unw
 dqC
 veD
-saN
+ngd
 rgr
-sPV
-omv
-aOV
-aOV
+jux
 omv
 omv
 omv
@@ -207238,10 +204376,13 @@ omv
 omv
 omv
 omv
-sPV
-iiJ
-xXE
-sPV
+omv
+omv
+omv
+omv
+omv
+omv
+omv
 usE
 eqK
 vrM
@@ -207309,12 +204450,12 @@ kfM
 kfM
 kfM
 kfM
+kfM
+kfM
+kfM
 wgB
-wgB
-wgB
-wgB
-wgB
-wgB
+kfM
+kfM
 kfM
 kfM
 kfM
@@ -207423,13 +204564,9 @@ bzZ
 unw
 dqC
 veD
-saN
+ngd
 rgr
-sPV
-omv
-omv
-aOV
-aOV
+jux
 omv
 omv
 omv
@@ -207440,10 +204577,14 @@ omv
 omv
 omv
 omv
-sPV
-iIm
-xXE
-sPV
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
 usE
 cBT
 vrM
@@ -207511,10 +204652,10 @@ kfM
 kfM
 kfM
 kfM
-kfM
-kfM
 wgB
 wgB
+wgB
+kfM
 kfM
 kfM
 kfM
@@ -207625,14 +204766,9 @@ hcB
 umA
 dqC
 veD
-saN
+ngd
 rgr
-sPV
-omv
-omv
-omv
-aOV
-aOV
+jux
 omv
 omv
 omv
@@ -207642,10 +204778,15 @@ omv
 omv
 omv
 omv
-sPV
-bQe
-mdI
-sPV
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
 usE
 rGP
 vrM
@@ -207827,9 +204968,9 @@ bro
 bro
 bro
 veD
-saN
+ngd
 rgr
-sPV
+jux
 omv
 omv
 omv
@@ -207844,10 +204985,10 @@ omv
 omv
 omv
 omv
-sPV
-iIm
-gYE
-sPV
+omv
+omv
+omv
+omv
 usE
 mzt
 vrM
@@ -208029,14 +205170,9 @@ xRO
 dNC
 bro
 veD
-saN
+ngd
 iLm
-sPV
-sPV
-sPV
-mnp
-sPV
-sPV
+jux
 omv
 omv
 omv
@@ -208046,10 +205182,15 @@ omv
 omv
 omv
 omv
-sPV
-iIm
-gYE
-sPV
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
 usE
 iyk
 vrM
@@ -208231,27 +205372,27 @@ hHf
 mVL
 amm
 veD
-saN
+ngd
 aRj
-sPV
-sPV
-qjr
-xXE
-mfH
-sPV
-sPV
-sPV
-sPV
-sPV
-sPV
-sPV
-sPV
-sPV
-sPV
-sPV
-iIm
-gYE
-sPV
+jux
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
 usE
 gbL
 vrM
@@ -208433,27 +205574,27 @@ iIA
 wfB
 amm
 veD
-saN
+ngd
 rgr
-pPu
-sPV
-eHU
-cxs
-cGa
-olE
-cGa
-cwg
-vOZ
-cGa
-gEJ
-cGa
-cGa
-eGJ
-eGJ
-olE
-iBu
-spW
-sPV
+jux
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
 usE
 atA
 vrM
@@ -208636,26 +205777,26 @@ bAo
 dfE
 lKe
 bkA
-gut
-sSx
-wLb
-pcr
-trR
-nZG
-jwO
-nZG
-nZG
-jSW
-lYc
-hko
-lYc
-kbo
-hSS
-swr
-rbM
-gcJ
-fGB
-sPV
+iYg
+jux
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
 usE
 anR
 vrM
@@ -208839,25 +205980,25 @@ amm
 veD
 ngd
 rgr
-pPu
-sPV
-xJj
-fZM
-rDK
-bgs
-mfH
-mfH
-xXE
-mfH
-isS
-mfH
-kUb
-mfH
-mfH
-bgs
-nxn
-oTn
-sPV
+jux
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
 usE
 vtn
 vrM
@@ -209041,25 +206182,25 @@ amm
 veD
 ngd
 aRj
-sPV
-sPV
-kOu
-iDQ
-xDl
-sPV
-sPV
-sPV
-sPV
-sPV
-gMI
-gMI
-hJR
-gMI
-gMI
-gMI
-nag
-txN
-gMI
+jux
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
 usE
 bII
 bII
@@ -209243,26 +206384,26 @@ bro
 veD
 ngd
 iLm
-sPV
-sPV
-sPV
-sPV
-sPV
-sPV
+jux
 omv
 omv
 omv
 omv
-gMI
-dxd
-bIN
-rhK
-gMI
-gMI
-idM
-vrN
-gMI
-gMI
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+mPt
 bhK
 diE
 bhK
@@ -209445,7 +206586,7 @@ jux
 veD
 ngd
 rgr
-sPV
+jux
 omv
 omv
 omv
@@ -209455,16 +206596,16 @@ omv
 omv
 omv
 omv
-gMI
-rOO
-tgI
-jKQ
-gMI
-gMI
-sFa
-cEu
-tpI
-gMI
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+mPt
 bhK
 bhK
 dql
@@ -209647,26 +206788,26 @@ jux
 xJo
 ngd
 rgr
-sPV
-sPV
-sPV
-sPV
-sPV
-gMI
-gMI
-gMI
-gMI
-gMI
-gMI
-mCg
-bIN
-jKQ
-utS
-waD
-hPf
-tYy
-hlX
-hXJ
+jux
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+mPt
 diE
 mGZ
 jux
@@ -209849,26 +206990,26 @@ dob
 gXB
 vwq
 vLZ
-sPV
-qPJ
-jKQ
-jKQ
-jKQ
-gMI
-psQ
-ndy
-yfY
-yfY
-mRT
-ndy
-tgI
-jKQ
-utS
-uCn
-nzU
-cRL
-hlX
-hXJ
+jux
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+mPt
 diE
 bhK
 ddD
@@ -210051,26 +207192,26 @@ jux
 xJo
 ngd
 rgr
-sPV
-jKQ
-jKQ
-jKQ
-jKQ
-brb
-rhK
-jKQ
-jKQ
-jKQ
-rhK
-rhK
-tHU
-rhK
-utS
-djS
-wNa
-nNM
-hlX
-hXJ
+jux
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+mPt
 diE
 bhK
 ddD
@@ -210253,26 +207394,26 @@ jux
 veD
 ngd
 rgr
-sPV
-alX
-qIf
-jKQ
-jKQ
-gMI
-rhK
-rhK
-rhK
-jKQ
-jKQ
-rhK
-qgm
-jKQ
-utS
-itP
-gak
-eez
-hlX
-hXJ
+jux
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+mPt
 diE
 bhK
 ddD
@@ -210455,26 +207596,26 @@ jux
 veD
 ngd
 rgr
-sPV
-gMI
-gMI
-mCg
-jKQ
-gMI
-jKQ
-jKQ
-rhK
-rhK
-rhK
-jKQ
-tHU
-jKQ
-gMI
-gMI
-sFa
-hyQ
-mEA
-gMI
+jux
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+mPt
 bhK
 bhK
 ddD
@@ -210657,26 +207798,26 @@ dQb
 veD
 ngd
 rgr
-sPV
-uzU
-mBk
-jKQ
-jKQ
-gMI
-anb
-kHV
-epz
-xDp
-iKO
-xXO
-gWr
-stC
-rOb
-gMI
-jrJ
-xrO
-gMI
-gMI
+jux
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+mPt
 bhK
 bhK
 ddD
@@ -210859,26 +208000,26 @@ oPy
 tYG
 ngd
 sMP
-sPV
-gMI
-gMI
-mCg
-jKQ
-gMI
-nJD
-kHV
-dPI
-qgm
-olM
-jKQ
-rhK
-qgm
-jKQ
-gMI
-pHq
-dax
-gMI
-gMI
+jux
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+mPt
 bhK
 aWp
 jux
@@ -211061,26 +208202,26 @@ dRs
 tYG
 ngd
 aRj
-sPV
-jeJ
-mBk
-jKQ
-jKQ
-gMI
-gMI
-gMI
-gMI
-reg
-gMI
-wgO
-gMI
-reg
-gMI
-gMI
-fXX
-uby
-gMI
-gMI
+jux
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+mPt
+mPt
+mPt
+mPt
+mPt
 bhK
 fcg
 jux
@@ -211263,23 +208404,23 @@ ceR
 wHR
 ngd
 rgr
-sPV
-gMI
-gMI
-mCg
-jKQ
-gMI
-wjr
-kLD
-pRn
-mod
-gMI
-wjr
-pRn
-lXR
-eux
-gMI
-xCo
+jux
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+mPt
+keV
 keV
 keV
 vhj
@@ -211465,23 +208606,23 @@ jux
 veD
 ngd
 rgr
-sPV
-jeJ
-mBk
-jKQ
-jKQ
-gMI
-khU
-xkW
-kyA
-fnR
-gMI
-khU
-kyA
-ykU
-cdM
-gMI
-wSg
+jux
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+mPt
+dkg
 dkg
 keV
 vhj
@@ -211516,7 +208657,7 @@ hKS
 hKS
 hKS
 hKS
-dSF
+hKS
 lmX
 wlf
 nBE
@@ -211672,18 +208813,18 @@ fCa
 fCa
 fCa
 fCa
-gMI
-bRd
-cdM
-bRd
-cSK
-gMI
-tJm
-nef
-cdM
-pKR
-gMI
-xCo
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+mPt
+keV
 keV
 keV
 vhj
@@ -211875,17 +209016,17 @@ iJK
 aSy
 fCa
 gMI
-gMI
-gMI
-gMI
-gMI
-gMI
-gMI
-gMI
-gMI
-gMI
-gMI
-fXX
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+omv
+mPt
+uby
 uby
 fCa
 fCa
@@ -212678,8 +209819,8 @@ veD
 ngd
 rgr
 fCa
-cbw
-cbw
+fCa
+fCa
 kMh
 cTn
 cTn
@@ -214901,7 +212042,7 @@ aqt
 bps
 cWY
 yjX
-lOH
+rOO
 uFr
 xKQ
 epd


### PR DESCRIPTION
Removes the Custodians and Fontaine factions from the map entirely. 